### PR TITLE
TC-2721 Parallel installation

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -272,6 +272,11 @@ spec:
                       initialDelaySeconds: 15
                       periodSeconds: 20
                     name: manager
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                     readinessProbe:
                       httpGet:
                         path: /readyz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,11 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
See: https://issues.redhat.com/browse/TC-2721
Helm Operator receive all the events unstructured, no matter if the operators are fully isolated, changing clusterroles into roles and configuring explicitly the `Namespace` to watch.
So we need to filter the events and this works fine.