### PR TITLE
Update helm-chart

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
@@ -79,7 +79,7 @@ data:
 {{/*
 Create the authenticator default configuration.
 
-Arugments: (dict)
+Arguments: (dict)
   * root - .
   * module - module object
 */}}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_common.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_common.tpl
@@ -9,7 +9,7 @@ Arguments: string or object
 value: {{ . | quote }}
 {{- else if empty . }}{{/* if it's empty, we drop the value section */ -}}
 {{- else }}
-{{- . | toYaml }}{{/* otherwise, it must be an oject */ -}}
+{{- . | toYaml }}{{/* otherwise, it must be an object */ -}}
 {{- end }}
 
 {{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_infrastructure.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_infrastructure.tpl
@@ -38,17 +38,21 @@ Arguments (dict):
 {{- if eq ( include "trustification.application.metrics.enabled" .root ) "true" }}
 - name: METRICS
   value: "enabled"
+{{ with .root.Values.metrics.otelMetricExportInterval }}
+- name: OTEL_METRIC_EXPORT_INTERVAL
+  value: {{ . | quote }}
+{{ end }}
 {{- end }}
 
 {{- if eq ( include "trustification.application.tracing.enabled" .root ) "true" }}
 - name: TRACING
   value: "enabled"
 - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
-  value: "32"
+  value: {{ .root.Values.tracing.otelBspMaxExportBatchSize | default 512 | quote }}
 - name: OTEL_TRACES_SAMPLER
-  value: parentbased_traceidratio
+  value: {{ .root.Values.tracing.otelTracesSampler | default "parentbased_traceidratio" | quote }}
 - name: OTEL_TRACES_SAMPLER_ARG
-  value: "0.1"
+  value: {{ .root.Values.tracing.otelTracesSamplerArg | default "" | quote }}
 {{- end }}
 
 {{- if eq ( include "trustification.application.collector.enabled" .root ) "true" }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_ingress.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_ingress.tpl
@@ -28,7 +28,7 @@ Arguments (dict):
 {{- end }}
 
 {{/*
-A default ingress definion.
+A default ingress definition.
 
 Arguments (dict):
   * root - .
@@ -61,15 +61,35 @@ metadata:
 
 spec:
   {{- include "trustification.ingress.className" . | nindent 2 }}
+  {{- $tlsConfig := .module.ingress.tls | default .root.Values.ingress.tls -}}
+  {{- $ingressHosts := .module.ingress.hosts | default .root.Values.ingress.hosts -}}
+  {{- if (empty $ingressHosts) }}
+    {{- $ingressHosts = list .host }}
+  {{- end }}
+  {{- $tlsEnabled := include "trustification.tls.serviceEnabled" .root -}}
+  {{- if and (eq $tlsEnabled "true") (or (not (empty $tlsConfig)) (not (empty $ingressHosts))) }}
+  tls:
+    {{- if (not (empty $tlsConfig)) }}
+    {{- $tlsConfig | toYaml | nindent 4 }}
+    {{- else if (not (empty $ingressHosts)) }}
+    - hosts:
+        {{- range $ingressHosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ include "trustification.common.name" . }}-tls
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .host | quote }}
+    {{- range $ingressHosts }}
+    - host: {{ . | quote }}
       http:
         paths:
           - pathType: Prefix
             path: /
             backend:
               service:
-                name: {{ include "trustification.common.name" . }}
+                name: {{ include "trustification.common.name" $ }}
                 port:
                   name: endpoint
+    {{- end }}
 {{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_value.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_value.tpl
@@ -1,5 +1,5 @@
 {{/*
-Get value from a resource. Currenlty only from secrets.
+Get value from a resource. Currently only from secrets.
 
 Arguments (dict):
   * .root - .

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/050-Ingress.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/050-Ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.modules.server.enabled }}
+{{- if and .Values.modules.server.enabled .Values.ingress.enabled }}
 {{- $mod := dict "root" . "name" "server" "component" "server" "module" .Values.modules.server -}}
 {{- include "trustification.ingress.defaultIngress" ( set (deepCopy $mod) "host" (include "trustification.host.server" $mod ) ) }}
 {{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -73,11 +73,41 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls whether ingress resources should be created globally. Defaults to true for backward compatibility.\n"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Multiple hostnames for the ingress. If specified, overrides the single host configuration.\nThese hosts will be automatically used for TLS configuration if no explicit TLS config is provided.\n"
+        },
         "className": {
           "type": "string"
         },
         "additionalAnnotations": {
           "type": "object"
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "secretName": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.\nIf not specified and hosts are defined, TLS will be automatically configured using the hosts.\n"
         }
       }
     },
@@ -103,6 +133,10 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable support for application metrics.\n"
+        },
+        "otelMetricExportInterval": {
+          "type": "integer",
+          "description": "The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.\n"
         }
       }
     },
@@ -113,6 +147,19 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable support for distributed tracing.\n"
+        },
+        "otelBspMaxExportBatchSize": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.\n"
+        },
+        "otelTracesSampler": {
+          "type": "string",
+          "description": "The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.\n"
+        },
+        "otelTracesSamplerArg": {
+          "type": "string",
+          "description": "The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.\n"
         }
       }
     },
@@ -122,6 +169,7 @@
       "properties": {
         "endpoint": {
           "type": "string",
+          "pattern": "^(http|https)://",
           "description": "OpenTelemetry collector endpoint for tracing and metrics.\n"
         }
       }
@@ -298,7 +346,7 @@
                   "type": "object",
                   "description": "The importers to create",
                   "additionalProperties": {
-                    "$ref": "https://raw.githubusercontent.com/trustification/trustify/main/modules/importer/schema/importer.json"
+                    "$ref": "https://raw.githubusercontent.com/guacsec/trustify/main/modules/importer/schema/importer.json"
                   }
                 }
               }
@@ -471,6 +519,10 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "otelMetricExportInterval": {
+          "type": "integer",
+          "description": "The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.\n"
         }
       }
     },
@@ -491,6 +543,19 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "otelBspMaxExportBatchSize": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.\n"
+        },
+        "otelTracesSampler": {
+          "type": "string",
+          "description": "The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.\n"
+        },
+        "otelTracesSamplerArg": {
+          "type": "string",
+          "description": "The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.\n"
         }
       }
     },
@@ -563,6 +628,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Hostnames for the ingress. If not specified, defaults to [{service-name}{appDomain}].\nThese hosts will be automatically used for TLS configuration if no explicit TLS config is provided.\n"
+        },
         "className": {
           "type": "string"
         },
@@ -572,6 +644,24 @@
             "type": "string"
           },
           "description": "Additional annotations which will be used as annotations on `Ingress` resources.\n"
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "secretName": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.\nIf not specified and hosts are defined, TLS will be automatically configured using the hosts.\n"
         }
       }
     },
@@ -609,7 +699,7 @@
           ],
           "properties": {
             "content": {
-              "$ref": "https://raw.githubusercontent.com/trustification/trustify/main/common/auth/schema/auth.json"
+              "$ref": "https://raw.githubusercontent.com/guacsec/trustify/main/common/auth/schema/auth.json"
             }
           }
         },

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -77,10 +77,36 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      enabled:
+        type: boolean
+        default: true
+        description: |
+          Controls whether ingress resources should be created globally. Defaults to true for backward compatibility.
+      hosts:
+        type: array
+        items:
+          type: string
+        description: |
+          Multiple hostnames for the ingress. If specified, overrides the single host configuration.
+          These hosts will be automatically used for TLS configuration if no explicit TLS config is provided.
       className:
         type: string
       additionalAnnotations:
         type: object
+      tls:
+        type: array
+        items:
+          type: object
+          properties:
+            hosts:
+              type: array
+              items:
+                type: string
+            secretName:
+              type: string
+        description: |
+          TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.
+          If not specified and hosts are defined, TLS will be automatically configured using the hosts.
 
   infrastructure:
     type: object
@@ -106,6 +132,10 @@ properties:
         type: boolean
         description: |
           Enable support for application metrics.
+      otelMetricExportInterval:
+        type: integer
+        description: |
+          The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.
 
   tracing:
     type: object
@@ -115,6 +145,19 @@ properties:
         type: boolean
         description: |
           Enable support for distributed tracing.
+      otelBspMaxExportBatchSize:
+        type: integer
+        minimum: 1
+        description: |
+          The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.
+      otelTracesSampler:
+        type: string
+        description: |
+          The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.
+      otelTracesSamplerArg:
+        type: string
+        description: |
+          The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.
 
   collector:
     type: object
@@ -122,6 +165,7 @@ properties:
     properties:
       endpoint:
         type: string
+        pattern: ^(http|https)://
         description: |
           OpenTelemetry collector endpoint for tracing and metrics.
 
@@ -224,7 +268,7 @@ properties:
                 type: object
                 description: The importers to create
                 additionalProperties:
-                  $ref: "https://raw.githubusercontent.com/trustification/trustify/main/modules/importer/schema/importer.json"
+                  $ref: "https://raw.githubusercontent.com/guacsec/trustify/main/modules/importer/schema/importer.json"
 
   database:
     $ref: "#/definitions/PostgresConfig"
@@ -350,6 +394,10 @@ definitions:
     properties:
       enabled:
         type: boolean
+      otelMetricExportInterval:
+        type: integer
+        description: |
+          The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.
 
   Tracing:
     type: object
@@ -365,6 +413,19 @@ definitions:
     properties:
       enabled:
         type: boolean
+      otelBspMaxExportBatchSize:
+        type: integer
+        minimum: 1
+        description: |
+          The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.
+      otelTracesSampler:
+        type: string
+        description: |
+          The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.
+      otelTracesSamplerArg:
+        type: string
+        description: |
+          The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.
 
   Image:
     type: object
@@ -417,6 +478,13 @@ definitions:
     type: object
     additionalProperties: false
     properties:
+      hosts:
+        type: array
+        items:
+          type: string
+        description: |
+          Hostnames for the ingress. If not specified, defaults to [{service-name}{appDomain}].
+          These hosts will be automatically used for TLS configuration if no explicit TLS config is provided.
       className:
         type: string
       additionalAnnotations:
@@ -425,6 +493,20 @@ definitions:
           type: string
         description: |
           Additional annotations which will be used as annotations on `Ingress` resources.
+      tls:
+        type: array
+        items:
+          type: object
+          properties:
+            hosts:
+              type: array
+              items:
+                type: string
+            secretName:
+              type: string
+        description: |
+          TLS configuration for the ingress. Each item can specify hosts and secretName for TLS termination.
+          If not specified and hosts are defined, TLS will be automatically configured using the hosts.
 
   Feature:
     type: object
@@ -459,7 +541,7 @@ definitions:
           - content
         properties:
           content:
-            $ref: "https://raw.githubusercontent.com/trustification/trustify/main/common/auth/schema/auth.json"
+            $ref: "https://raw.githubusercontent.com/guacsec/trustify/main/common/auth/schema/auth.json"
       - type: object
         additionalProperties: false
         required:
@@ -774,4 +856,3 @@ definitions:
           The number of HTTP workers of the Actix application.
 
           Also see: <https://actix.rs/docs/server/#multi-threading>
-

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -8,7 +8,8 @@ image:
 
 rust: {}
 
-ingress: {}
+ingress:
+  enabled: true
 
 tls: {}
 


### PR DESCRIPTION
## Summary by Sourcery

Improve the redhat-trusted-profile-analyzer Helm chart by enhancing ingress templating with multi-host and TLS overrides, making tracing and metrics environment variables configurable, gating Ingress creation on an enable flag, and updating the default image reference with minor typo corrections.

New Features:
- Add support for module-level and global TLS configuration and multiple ingress hosts in the Helm chart

Enhancements:
- Introduce OTEL_METRIC_EXPORT_INTERVAL environment variable and make OTEL BSP batch size, sampler, and sampler argument configurable via values
- Require .Values.ingress.enabled flag to control rendering of the Ingress resource

Chores:
- Fix typos in comment blocks across helper templates
- Update default container image fullName to new quay.io reference in values.yaml