### PR TITLE
0.4.0

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
             "collector": {},
             "database": {},
             "image": {
-              "fullName": "registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170",
+              "fullName": "registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e",
               "pullPolicy": "IfNotPresent"
             },
             "infrastructure": {
@@ -380,6 +380,6 @@ spec:
   relatedImages:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:3a3ede0945fc413965d5a2efa8d94f44349c8a12158ca8bdff82379c0fd9d576
       name: manager
-    - image: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170
+    - image: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e
       name: rhtpa-trustification-service-rhel9-ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170-annotation
   version: 1.0.3

--- a/config/samples/v1_trustedprofileanalyzer.yaml
+++ b/config/samples/v1_trustedprofileanalyzer.yaml
@@ -8,7 +8,7 @@ spec:
   collector: {}
   database: {}
   image:
-    fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170
+    fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e
     pullPolicy: IfNotPresent
   infrastructure:
     port: 9010

--- a/devel/trusted-profile-analyzer-demo.yaml
+++ b/devel/trusted-profile-analyzer-demo.yaml
@@ -30,7 +30,7 @@ spec:
           name: infrastructure-postgresql
           key: postgres-password
   image:
-    fullName: 'registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170'
+    fullName: 'registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e'
     pullPolicy: IfNotPresent
   infrastructure:
     port: 9010

--- a/devel/trusted-profile-analyzer-ocp.yaml
+++ b/devel/trusted-profile-analyzer-ocp.yaml
@@ -30,7 +30,7 @@ spec:
           name: infrastructure-postgresql
           key: postgres-password
   image:
-    fullName: 'registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170'
+    fullName: 'registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e'
     pullPolicy: IfNotPresent
   infrastructure:
     port: 9010

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:ce8734133f8de06a675eeac3cb1b31f714d10f81710880452b6a98222ebc7170
+  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e
   pullPolicy: IfNotPresent
 
 rust: {}


### PR DESCRIPTION
## Summary by Sourcery

Update trustification-service image references to the new SHA across all deployment and configuration files

Enhancements:
- Bump registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9 image digest to sha256:4365bd4de518b86d08be84d10e6bc923e4759d8fae9b34746604f08acf74b32e in the CSV manifest
- Update sample, demo, and OCP YAML configurations to use the new trustification-service image digest
- Refresh Helm chart values.yaml to reference the updated trustification-service image digest