### PR TITLE
CPE

### DIFF
--- a/.tekton/operator-1-0-z-pull-request.yaml
+++ b/.tekton/operator-1-0-z-pull-request.yaml
@@ -537,6 +537,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: ["v1.0.3-rc","{{revision}}"]
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-1-0-z-push.yaml
+++ b/.tekton/operator-1-0-z-push.yaml
@@ -535,6 +535,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: ["v1.0.3-rc","{{revision}}"]
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-bundle-1-0-z-pull-request.yaml
+++ b/.tekton/operator-bundle-1-0-z-pull-request.yaml
@@ -538,6 +538,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: [ "v1.0.3-rc","{{revision}}" ]
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-bundle-1-0-z-push.yaml
+++ b/.tekton/operator-bundle-1-0-z-push.yaml
@@ -536,6 +536,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: [ "v1.0.3-rc","{{revision}}" ]
       runAfter:
       - build-image-index
       taskRef:

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -43,7 +43,7 @@ LABEL summary="RHTPA Operator"
 LABEL version="1.0.3"
 LABEL release=1.0.3
 LABEL maintainer="Red Hat"
-LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.1::el9"
+LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 
 LABEL features.operators.openshift.io/cni="false"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -14,7 +14,7 @@ LABEL distribution-scope="public"
 LABEL url="https://www.redhat.com"
 LABEL version="1.0.3"
 LABEL release=1.0.3
-LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.1::el9"
+LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 
 LABEL features.operators.openshift.io/cni="false"


### PR DESCRIPTION
## Summary by Sourcery

Update operator bundle Dockerfile metadata labels

Enhancements:
- Bump CPE label to 2.2 in bundle.Dockerfile
- Add konflux.additional-tags label with v1.0.3-rc