### PR TITLE
Move version tag

### DIFF
--- a/.tekton/operator-1-0-z-pull-request.yaml
+++ b/.tekton/operator-1-0-z-pull-request.yaml
@@ -537,8 +537,6 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: ADDITIONAL_TAGS
-        value: ["v1.0.3-rc","{{revision}}"]
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-1-0-z-push.yaml
+++ b/.tekton/operator-1-0-z-push.yaml
@@ -19,6 +19,10 @@ metadata:
   namespace: trusted-content-tenant
 spec:
   params:
+  - name: version
+    value: "v1.0.3"
+  - name: version-postfix-qe
+    value: "-rc1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -536,7 +540,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: ["v1.0.3-rc","{{revision}}"]
+        value: [ "{{version}}{{version-postfix-qe}}","{{revision}}" ]
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-bundle-1-0-z-pull-request.yaml
+++ b/.tekton/operator-bundle-1-0-z-pull-request.yaml
@@ -538,8 +538,6 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: ADDITIONAL_TAGS
-        value: [ "v1.0.3-rc","{{revision}}" ]
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-bundle-1-0-z-push.yaml
+++ b/.tekton/operator-bundle-1-0-z-push.yaml
@@ -18,6 +18,10 @@ metadata:
   namespace: trusted-content-tenant
 spec:
   params:
+  - name: version
+    value: "v1.0.3"
+  - name: version-postfix-qe
+    value: "-rc1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -537,7 +541,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: [ "v1.0.3-rc","{{revision}}" ]
+        value: [ "{{version}}{{version-postfix-qe}}","{{revision}}" ]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Parameterize version tagging for push pipelines and disable additional tagging in pull-request pipelines

Enhancements:
- Add version and version-postfix-qe parameters to operator push pipelines
- Update ADDITIONAL_TAGS in push pipelines to use version and version-postfix-qe parameters
- Comment out ADDITIONAL_TAGS in pull-request pipelines to disable extra tagging