### PR TITLE
Apply tags on pull

### DIFF
--- a/.tekton/operator-1-0-z-push.yaml
+++ b/.tekton/operator-1-0-z-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: version
     value: "v1.0.3"
   - name: version-postfix-qe
-    value: "-rc1"
+    value: "-rc"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -540,7 +540,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: [ "{{version}}{{version-postfix-qe}}","{{revision}}" ]
+      value: ['$(params.version)$(params.version-postfix-qe)','{{revision}}']
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/operator-bundle-1-0-z-push.yaml
+++ b/.tekton/operator-bundle-1-0-z-push.yaml
@@ -21,7 +21,7 @@ spec:
   - name: version
     value: "v1.0.3"
   - name: version-postfix-qe
-    value: "-rc1"
+    value: "-rc"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -541,7 +541,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-        value: [ "{{version}}{{version-postfix-qe}}","{{revision}}" ]
+        value: ['$(params.version)$(params.version-postfix-qe)','{{revision}}']
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Update Tekton push pipelines to standardize version postfix and switch ADDITIONAL_TAGS to use parameter expansion

Enhancements:
- Change version-postfix-qe default value from "-rc1" to "-rc" in operator and operator-bundle push pipelines
- Replace literal template tags with Tekton parameter syntax for ADDITIONAL_TAGS in operator and operator-bundle pipelines