### PR TITLE
Update Helm chart keycloak realm

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_oidc.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_oidc.tpl
@@ -73,7 +73,7 @@ Arguments (dict):
 {{- else if .root.Values.oidc.issuerUrl }}
 {{- .root.Values.oidc.issuerUrl }}
 {{- else -}}
-{{ include "trustification.tls.http.protocol" . }}://sso{{ .root.Values.appDomain }}/realms/chicken
+{{ include "trustification.tls.http.protocol" . }}://sso{{ .root.Values.appDomain }}/realms/trustify
 {{- end }}
 {{- end }}
 

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -377,6 +377,9 @@
     "keycloak": {
       "$ref": "#/definitions/Feature"
     },
+    "keycloakPostInstall": {
+      "$ref": "#/definitions/Feature"
+    },
     "postgresql": {
       "$ref": "#/definitions/Feature"
     },

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -290,6 +290,9 @@ properties:
   keycloak:
     $ref: "#/definitions/Feature"
 
+  keycloakPostInstall:
+    $ref: "#/definitions/Feature"
+
   postgresql:
     $ref: "#/definitions/Feature"
 


### PR DESCRIPTION
## Summary by Sourcery

Update the Helm chart to introduce a post-install Keycloak configuration hook and adjust the default realm name to trustify in the OIDC configuration

Enhancements:
- Add keycloakPostInstall feature definition to the Helm chart values schema
- Update default Keycloak realm in the OIDC helper template from "chicken" to "trustify"