### PR TITLE
Update min kube version on helm chart

### DIFF
--- a/.tekton/operator-1-0-z-push.yaml
+++ b/.tekton/operator-1-0-z-push.yaml
@@ -540,7 +540,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
-      value: ['$(params.version)$(params.version-postfix-qe)','{{revision}}']
+        value: ['$(params.version)$(params.version-postfix-qe)','{{revision}}']
       runAfter:
       - build-image-index
       taskRef:

--- a/helm-charts/redhat-trusted-profile-analyzer/Chart.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redhat-trusted-profile-analyzer
 description: An Helm chart for deploying Red Hat Trusted Profile Analyzer (RHTPA)
 
-kubeVersion: ^1.25.0
+kubeVersion: ^1.29.0
 
 maintainers:
   - name: Red Hat


### PR DESCRIPTION
## Summary by Sourcery

Bump Helm chart minimum Kubernetes version to ^1.29.0 and fix indentation in Tekton pipeline configuration

CI:
- Fix indentation of ADDITIONAL_TAGS value in the operator-1-0-z-push Tekton pipeline

Deployment:
- Update Helm chart redhat-trusted-profile-analyzer to require Kubernetes v1.29.0 or later