### PR TITLE
fix: respect user defined Ingress TLS configuration

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_ingress.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_ingress.tpl
@@ -66,18 +66,9 @@ spec:
   {{- if (empty $ingressHosts) }}
     {{- $ingressHosts = list .host }}
   {{- end }}
-  {{- $tlsEnabled := include "trustification.tls.serviceEnabled" .root -}}
-  {{- if and (eq $tlsEnabled "true") (or (not (empty $tlsConfig)) (not (empty $ingressHosts))) }}
+  {{- if (not (empty $tlsConfig)) }}
   tls:
-    {{- if (not (empty $tlsConfig)) }}
     {{- $tlsConfig | toYaml | nindent 4 }}
-    {{- else if (not (empty $ingressHosts)) }}
-    - hosts:
-        {{- range $ingressHosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ include "trustification.common.name" . }}-tls
-    {{- end }}
   {{- end }}
   rules:
     {{- range $ingressHosts }}


### PR DESCRIPTION
See: https://github.com/guacsec/trustify-helm-charts/pull/76
## Summary by Sourcery

Simplify Helm Chart ingress TLS handling to only include user-provided TLS configuration and remove default fallback logic.

Bug Fixes:
- Only render the TLS section when a custom tlsConfig is supplied, preventing automatic TLS secret and host mapping

Enhancements:
- Remove serviceEnabled check and default hosts-based TLS fallback from the ingress template