### PR TITLE
Regenerated roles

### DIFF
--- a/bundle/manifests/allow-get-ingress-cluster_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/allow-get-ingress-cluster_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: allow-get-ingress-cluster
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch

--- a/bundle/manifests/allow-get-ingress_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/allow-get-ingress_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: allow-get-ingress
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch

--- a/bundle/manifests/bind-get-ingress_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/bind-get-ingress_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-ingress-reader-binding
+  name: bind-get-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ingress-reader
+  kind: Role
+  name: allow-get-ingress
 subjects:
 - kind: ServiceAccount
-  name: rhtpa-operator-controller-manager
+  name: controller-manager
   namespace: placeholder

--- a/bundle/manifests/bind-job_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/bind-job_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-bind-job
+  name: bind-job
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: rhtpa-operator-role-job
+  name: role-job
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/bundle/manifests/controller-manager_v1_serviceaccount.yaml
+++ b/bundle/manifests/controller-manager_v1_serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  creationTimestamp: null
   labels:
-    app.kubernetes.io/name: rhtpa-operator
     app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
   name: controller-manager
-  namespace: placeholder

--- a/bundle/manifests/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/bundle/manifests/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -2,11 +2,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-bind-job
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: rhtpa-operator-role-job
+  name: leader-election-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/bundle/manifests/manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - rhtpa.io
+  resources:
+  - trustedprofileanalyzers
+  - trustedprofileanalyzers/status
+  - trustedprofileanalyzers/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/bundle/manifests/manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,12 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-bind-job
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rhtpa-operator-role-job
+  kind: ClusterRole
+  name: rhtpa-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/bundle/manifests/metrics-auth-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/metrics-auth-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-bind-job
+  name: metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rhtpa-operator-role-job
+  kind: ClusterRole
+  name: rhtpa-operator-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/rhtpa-operator-allow-get-ingress_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/rhtpa-operator-allow-get-ingress_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: rhtpa-operator-allow-get-ingress
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch

--- a/bundle/manifests/rhtpa-operator-bind-get-ingress_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-bind-get-ingress_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -6,8 +6,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: allow-get-ingress
+  name: rhtpa-operator-allow-get-ingress
 subjects:
 - kind: ServiceAccount
-  name: rhtpa-operator-controller-manager
+  name: controller-manager
   namespace: placeholder

--- a/bundle/manifests/rhtpa-operator-leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/rhtpa-operator-leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: rhtpa-operator-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -2,12 +2,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-bind-job
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: rhtpa-operator-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: rhtpa-operator-role-job
+  name: rhtpa-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/rhtpa-operator-manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/rhtpa-operator-manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: rhtpa-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - rhtpa.io
+  resources:
+  - trustedprofileanalyzers
+  - trustedprofileanalyzers/status
+  - trustedprofileanalyzers/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/bundle/manifests/rhtpa-operator-manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,11 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metrics-auth-rolebinding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: rhtpa-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metrics-auth-role
+  name: rhtpa-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/bundle/manifests/rhtpa-operator-metrics-auth-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/rhtpa-operator-metrics-auth-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: rhtpa-operator-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: rhtpa-operator-bind-job
+  name: rhtpa-operator-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: rhtpa-operator-role-job
+  kind: ClusterRole
+  name: rhtpa-operator-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/rhtpa-operator-role-job_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/rhtpa-operator-role-job_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: rhtpa-operator-role-job
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -98,7 +98,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-09-10T12:03:15Z"
+    createdAt: "2025-10-28T14:42:11Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -112,8 +112,6 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Profile Analyzer"]'
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
-    repository: https://github.com/trustification/trusted-profile-analyzer-operator
-    support: Red Hat
   name: rhtpa-operator.v1.0.3
   namespace: placeholder
 spec:
@@ -123,25 +121,25 @@ spec:
       - kind: TrustedProfileAnalyzer
         name: trustedprofileanalyzers.rhtpa.io
         version: v1
-  description: |    
+  description: |
     Red Hat Trusted Profile Analyzer (RHTPA) provides a single source of truth for your software inventory across all your environments. You can verify the integrity of your in-house and third-party applications against their respective Software Bill of Materials (SBOM) document.  Trusted Profile Analyzer provides vulnerability, component and license transparency, strengthens your software supply chain security, and enables an accurate, up-to-date understanding of your software inventory.
 
     Features and Benefits:
 
     Enhanced Software Supply Chain Security: Offers critical transparency and integrity verification across the entire software lifecycle.
-    
+
     Reduced Operational Risk: Proactively identifies and helps remediate vulnerabilities minimizing risk and compliance violations.
-    
+
     Improved Compliance and Auditability: Simplifies the process of meeting regulatory requirements for software transparency and integrity by providing verifiable documentation and continuous monitoring.
-    
+
     Faster Remediation and Incident Response: Provides targeted, actionable insights to prioritize and accelerate the patching and remediation of vulnerabilities.
-    
+
     Increased Developer Productivity & Trust: Integrates security into existing workflows without significant overhead, allowing developers to build and deploy with greater confidence in the integrity of their code and components.
-    
+
     Centralized Visibility and Control: Consolidates disparate security information into a single pane of glass, offering a holistic view of your application security posture.
-  
+
     Red Hat Trusted Profile Analyzer is a crucial tool for any organization running applications on OpenShift that needs to confidently understand, verify, and secure the software they deploy, especially in an era of complex software supply chains and increasing regulatory scrutiny.
-    
+
     [Documentation](https://docs.redhat.com/en/documentation/red_hat_trusted_profile_analyzer/2.2).
   displayName: Red Hat Trusted Profile Analyzer
   icon:
@@ -161,6 +159,96 @@ spec:
                 - list
                 - watch
                 - delete
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+            - apiGroups:
+                - rhtpa.io
+              resources:
+                - trustedprofileanalyzers
+                - trustedprofileanalyzers/status
+                - trustedprofileanalyzers/finalizers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - services/finalizers
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - delete
+                - patch
             - apiGroups:
                 - ""
               resources:
@@ -264,6 +352,11 @@ spec:
                       - --metrics-bind-address=:8443
                       - --leader-elect
                       - --health-probe-bind-address=:8081
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
                     image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:2e1fcb0b5b10a58c20904f25661541116c3f12ed7c4bb3c983d8b220699363f6
                     livenessProbe:
                       httpGet:
@@ -272,11 +365,6 @@ spec:
                       initialDelaySeconds: 15
                       periodSeconds: 20
                     name: manager
-                    env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.namespace
                     readinessProbe:
                       httpGet:
                         path: /readyz
@@ -311,6 +399,7 @@ spec:
                 - list
                 - watch
                 - delete
+                - patch
             - apiGroups:
                 - batch
               resources:
@@ -321,6 +410,7 @@ spec:
                 - list
                 - watch
                 - delete
+                - patch
             - apiGroups:
                 - ""
               resources:
@@ -381,5 +471,5 @@ spec:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:2e1fcb0b5b10a58c20904f25661541116c3f12ed7c4bb3c983d8b220699363f6
       name: manager
     - image: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:b716530c3b6ee8a79814fc75f55b65d5bcfaa61ac50c9947348751904b8351c7
-      name: rhtpa-trustification-service-rhel9-b716530c3b6ee8a79814fc75f55b65d5bcfaa61ac50c9947348751904b8351c7-annotation
+      name: trusted-content-tenant/rhtpa-product-0-4-z-b716530c3b6ee8a79814fc75f55b65d5bcfaa61ac50c9947348751904b8351c7-annotation
   version: 1.0.3

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -473,5 +473,5 @@ spec:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:2e1fcb0b5b10a58c20904f25661541116c3f12ed7c4bb3c983d8b220699363f6
       name: manager
     - image: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:b716530c3b6ee8a79814fc75f55b65d5bcfaa61ac50c9947348751904b8351c7
-      name: trusted-content-tenant/rhtpa-product-0-4-z-b716530c3b6ee8a79814fc75f55b65d5bcfaa61ac50c9947348751904b8351c7-annotation
+      name: rhtpa-trustification-service-rhel9-b716530c3b6ee8a79814fc75f55b65d5bcfaa61ac50c9947348751904b8351c7-annotation
   version: 1.0.3

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -112,6 +112,8 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Profile Analyzer"]'
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://github.com/trustification/trusted-profile-analyzer-operator
+    support: Red Hat
   name: rhtpa-operator.v1.0.3
   namespace: placeholder
 spec:

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -446,6 +446,8 @@ spec:
                 - patch
           serviceAccountName: rhtpa-operator-controller-manager
     strategy: deployment
+  cleanup:
+    enabled: true
   installModes:
     - supported: true
       type: OwnNamespace

--- a/bundle/manifests/role-job_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/role-job_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: role-job
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch

--- a/bundle/manifests/trustedprofileanalyzer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/trustedprofileanalyzer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: trustedprofileanalyzer-editor-role
+rules:
+- apiGroups:
+  - rhtpa.io
+  resources:
+  - trustedprofileanalyzers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rhtpa.io
+  resources:
+  - trustedprofileanalyzers/status
+  verbs:
+  - get

--- a/bundle/manifests/trustedprofileanalyzer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/trustedprofileanalyzer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhtpa-operator
+  name: trustedprofileanalyzer-viewer-role
+rules:
+- apiGroups:
+  - rhtpa.io
+  resources:
+  - trustedprofileanalyzers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rhtpa.io
+  resources:
+  - trustedprofileanalyzers/status
+  verbs:
+  - get

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -11,7 +11,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  #namespace: system
   namespace: placeholder
   labels:
     control-plane: controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -11,7 +11,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
+  #namespace: system
+  namespace: placeholder
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: rhtpa-operator

--- a/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
@@ -48,6 +48,8 @@ spec:
     spec:
       deployments: null
     strategy: ""
+  cleanup:
+    enabled: true
   installModes:
     - supported: true
       type: OwnNamespace

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - ../default
 - ../samples
 - ../scorecard
+- ../rbac

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: placeholder

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -12,5 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  #namespace: system
   namespace: placeholder

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -12,4 +12,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  #namespace: system
+  namespace: placeholder

--- a/config/rbac/role_cluster_ingress.yaml
+++ b/config/rbac/role_cluster_ingress.yaml
@@ -6,4 +6,4 @@ metadata:
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
-  verbs: ["create", "get", "list", "watch", "delete"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch"]

--- a/config/rbac/role_ingress.yaml
+++ b/config/rbac/role_ingress.yaml
@@ -6,4 +6,4 @@ metadata:
 rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
-  verbs: ["create", "get", "list", "watch", "delete"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch"]

--- a/config/rbac/role_job.yaml
+++ b/config/rbac/role_job.yaml
@@ -6,4 +6,4 @@ metadata:
 rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["create", "get", "list", "watch", "delete"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch"]

--- a/config/rbac/rolebinding_ingress.yaml
+++ b/config/rbac/rolebinding_ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
 subjects:
 - kind: ServiceAccount
-  name: rhtpa-operator-controller-manager
+  name: controller-manager
   namespace: placeholder
 roleRef:
   kind: Role

--- a/config/rbac/rolebinding_job.yaml
+++ b/config/rbac/rolebinding_job.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: placeholder
 subjects:
 - kind: ServiceAccount
-  name: rhtpa-operator-controller-manager
+  name: controller-manager
+  namespace: placeholder
 roleRef:
   kind: Role
   name: role-job


### PR DESCRIPTION
## Summary by Sourcery

Regenerate and sync operator RBAC configuration and refresh CSV and deployment manifests.

Enhancements:
- Overhaul and add complete RBAC manifests: cluster roles, roles, rolebindings, and clusterrolebindings for manager, operator, leader election, metrics auth, ingress access, jobs, and trustedprofileanalyzer editor/viewer.
- Add patch verbs to various resource rules and standardize subjects to the `controller-manager` service account with placeholder namespace.
- Switch operator and trustification service images from registry.redhat.io to quay.io and update WATCH_NAMESPACE environment variable to use `olm.targetNamespaces`.
- Refresh OLM CSV metadata by updating the createdAt timestamp and removing deprecated repository and support annotations.
- Include the new RBAC overlay in kustomize manifests.