### PR TITLE
Restict service account

### DIFF
--- a/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: placeholder

--- a/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: placeholder

--- a/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system
+  namespace: placeholder


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Parametrize controller-manager service account namespace by using a placeholder instead of “system” in three RBAC manifests