### PR TITLE
Nudges

### DIFF
--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -5,10 +5,10 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/trustification/trusted-profile-analyzer-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*. , .*.json"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release/1.1.z"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release/1.1.z" && !files.all.all(f, f.matches('bundle/'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhtpa-operator-1-1-z
@@ -32,6 +32,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -5,10 +5,10 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/trustification/trusted-profile-analyzer-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*., .*.json"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release/1.1.z"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release/1.1.z"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhtpa-operator-1-1-z
@@ -32,6 +32,10 @@ spec:
     value: bundle.Dockerfile
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/trustification/trusted-profile-analyzer-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*., .*.json"
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*, .*.json"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release/1.1.z"


### PR DESCRIPTION
## Summary by Sourcery

Add build nudge configuration and flags to Tekton push pipelines and refine event filtering for operator 1.1.z.

Enhancements:
- Introduce build-nudge-files annotation in operator and bundle push pipelines to watch specific file patterns
- Add build-source-image and hermetic parameters to pipeline specs for both operator and bundle pipelines
- Update the on-cel-expression in the operator push pipeline to ignore changes within the bundle directory