### PR TITLE
Enabled nudge and tags

### DIFF
--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -5,10 +5,11 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/trustification/trusted-profile-analyzer-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*, .*.json"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release/1.1.z"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "release/1.1.z" && !files.all.all(f, f.matches('bundle/'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhtpa-operator-1-1-z
@@ -18,6 +19,10 @@ metadata:
   namespace: trusted-content-tenant
 spec:
   params:
+  - name: version
+    value: "v1.1.0"
+  - name: version-postfix-qe
+    value: "-rc"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -536,6 +541,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: [ '$(params.version)$(params.version-postfix-qe)','{{revision}}' ]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Update the Tekton push pipeline for the 1.1.z branch to enable file-based nudge detection, refine trigger conditions, and inject version-based tags

CI:
- Enable build-nudge-files for Dockerfile, YAML, Containerfile, and JSON changes
- Restrict pipeline runs to push events on release/1.1.z excluding bundle-only changes
- Add version and version-postfix-qe parameters
- Introduce ADDITIONAL_TAGS environment variable combining version, postfix, and commit revision