### PR TITLE
Revert "Restict service account"

### DIFF
--- a/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system


### PR DESCRIPTION
Reverts trustification/trusted-profile-analyzer-operator#359

## Summary by Sourcery

Revert the service account namespace restriction by restoring the "controller-manager" subject namespace to "system" in all related rolebinding manifests

Bug Fixes:
- Restore the "controller-manager" ServiceAccount namespace from "placeholder" to "system" in metrics-auth ClusterRoleBinding manifest
- Restore the "controller-manager" ServiceAccount namespace from "placeholder" to "system" in leader-election RoleBinding manifest
- Restore the "controller-manager" ServiceAccount namespace from "placeholder" to "system" in operator metrics-auth ClusterRoleBinding manifest