### PR TITLE
Revert "Restrict SA (#359)"

### DIFF
--- a/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system

--- a/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/rhtpa-operator-metrics-auth-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: placeholder
+  namespace: system


### PR DESCRIPTION
This reverts commit 514d5722fc45f674d8ff2467c93e5663921f2063.

## Summary by Sourcery

Bug Fixes:
- Restore ServiceAccount namespace from placeholder to system in metrics-auth and operator leader-election rolebindings