### PR TITLE
Remove related image

### DIFF
--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -22,7 +22,7 @@ spec:
     - name: version
       value: "v1.1.0"
     - name: version-postfix-qe
-      value: "-rc"
+      value: "-rc1"
     - name: git-url
       value: '{{source_url}}'
     - name: revision

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -21,7 +21,7 @@ spec:
     - name: version
       value: "v1.1.0"
     - name: version-postfix-qe
-      value: "-rc"
+      value: "-rc1"
     - name: git-url
       value: '{{source_url}}'
     - name: revision

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -373,6 +373,4 @@ spec:
   relatedImages:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:618810ffac4f2d4962693dc3537318e973fd507a98deb1260a7dd8f0153aff38
       name: manager
-    - image: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:1e7b633db296319a1c62b1ff026e12e2f830382f1201f55240996c5fc473b3aa
-      name: rhtpa-trustification-service-rhel9-d5cf4a5bff94b59197f668a63d29591e3bc92ee89402edc70039e592d75cb84e-annotation
   version: 1.1.0


### PR DESCRIPTION
## Summary by Sourcery

Update version postfix in Tekton pipelines and clean up the operator CSV by removing an outdated related image entry

Enhancements:
- Update version-postfix-qe environment variable from '-rc' to '-rc1' in Tekton operator push tasks
- Remove obsolete relatedImages entry for the trustification service from the ClusterServiceVersion manifest