### PR TITLE
Update system information client scope to Auth template

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
@@ -152,6 +152,7 @@ authentication:
           - "read.metadata"
           - "update.metadata"
           - "delete.metadata"
+          - "read.systemInformation"
         "trustify/sbom":
           - "create.sbom"
           - "read.sbom"
@@ -172,6 +173,7 @@ authentication:
       issuerUrl: {{ include "trustification.oidc.issuerUrlForClient" (dict "root" .root "clientId" "frontend" ) }}
       scopeMappings: &keycloakScopeMappings
         "create:document": [ "create.advisory", "create.importer", "create.metadata", "create.sbom", "create.weakness", "upload.dataset" ]
+        "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.weakness", "read.systemInformation" ]
         "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.weakness" ]
         "update:document": [ "update.advisory", "update.importer", "update.metadata", "update.sbom", "update.weakness" ]
         "delete:document": [ "delete.advisory", "delete.importer", "delete.metadata", "delete.sbom", "delete.vulnerability", "delete.weakness" ]

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
@@ -174,7 +174,6 @@ authentication:
       scopeMappings: &keycloakScopeMappings
         "create:document": [ "create.advisory", "create.importer", "create.metadata", "create.sbom", "create.weakness", "upload.dataset" ]
         "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.weakness", "read.systemInformation" ]
-        "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.weakness" ]
         "update:document": [ "update.advisory", "update.importer", "update.metadata", "update.sbom", "update.weakness" ]
         "delete:document": [ "delete.advisory", "delete.importer", "delete.metadata", "delete.sbom", "delete.vulnerability", "delete.weakness" ]
       {{- with .root.Values.tls.additionalTrustAnchor }}


### PR DESCRIPTION
See https://github.com/guacsec/trustify-helm-charts/pull/81

## Summary by Sourcery

Enhance the Keycloak OIDC auth template by adding the read.systemInformation scope to the system information client and incorporating it into the frontend's read:document scopeMappings

Enhancements:
- Add read.systemInformation permission to the authentication template for system information client scope
- Include read.systemInformation in the Keycloak scopeMappings for read:document