### PR TITLE
Single Namespace restored

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -270,6 +270,11 @@ spec:
                       initialDelaySeconds: 15
                       periodSeconds: 20
                     name: manager
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                     readinessProbe:
                       httpGet:
                         path: /readyz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,11 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -41,6 +42,7 @@ var (
 	setupLog                       = ctrl.Log.WithName("setup")
 	defaultMaxConcurrentReconciles = runtime.NumCPU()
 	defaultReconcilePeriod         = time.Minute
+	watchNamespace                 = os.Getenv("WATCH_NAMESPACE")
 )
 
 func init() {
@@ -74,6 +76,18 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	var cacheOpts cache.Options
+	if watchNamespace != "" {
+		setupLog.Info("Watching specific namespace", "namespace", watchNamespace)
+		cacheOpts = cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				watchNamespace: {},
+			},
+		}
+	} else {
+		setupLog.Info("Watching all namespaces")
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: server.Options{
@@ -82,6 +96,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       leaderElectionID,
+		Cache:                  cacheOpts,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
<img width="3440" height="1440" alt="trustify" src="https://github.com/user-attachments/assets/53d8a81c-bca5-4e4f-b123-7b490b43e24d" />
<img width="3440" height="1440" alt="trustifyb" src="https://github.com/user-attachments/assets/45c97324-9200-4813-aa36-21d58307bc74" />



## Summary by Sourcery

Configure the operator to watch either a single namespace or all namespaces based on an environment variable.

New Features:
- Allow configuring the controller-runtime cache to restrict watching to a specific namespace via the WATCH_NAMESPACE environment variable.

Enhancements:
- Populate WATCH_NAMESPACE from the operator pod's namespace in both the CSV and manager deployment manifests so the operator defaults to watching its own namespace.