### PR TITLE
Bump version

### DIFF
--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -20,9 +20,9 @@ metadata:
 spec:
   params:
     - name: version
-      value: "v1.1.0"
+      value: "v1.1.1"
     - name: version-postfix-qe
-      value: "-rc1"
+      value: "-rc"
     - name: git-url
       value: '{{source_url}}'
     - name: revision

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   params:
     - name: version
-      value: "v1.1.0"
+      value: "v1.1.1"
     - name: version-postfix-qe
-      value: "-rc1"
+      value: "-rc"
     - name: git-url
       value: '{{source_url}}'
     - name: revision

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -37,8 +37,8 @@ LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer
 LABEL name="rhtpa/rhtpa-rhel9-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="1.0.3"
-LABEL release=1.0.3
+LABEL version="1.1.1"
+LABEL release=1.1.1
 LABEL maintainer="Red Hat"
 
 RUN microdnf update -y && microdnf clean all -y

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -1,5 +1,5 @@
-# Build the manager binary 9.6-1756993846/1.24.6-1756993846
-FROM registry.access.redhat.com/ubi9/go-toolset:9.7-1763633888@sha256:71f121a44270e46a17a548d6b92096a1a0fb56db44927ad318d095177d6dce4b AS builder
+# Build the manager binary 9.7-1764620329 1.25.3-1764620329
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:2e8adc5be8eba060e919a6f7309a7b5ef09dd72d3ae9e747b9eb02e96f35a0f5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -40,8 +40,8 @@ LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer
 LABEL name="rhtpa/rhtpa-rhel9-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="1.1.0"
-LABEL release=1.1.0
+LABEL version="1.1.1"
+LABEL release=1.1.1
 LABEL maintainer="Red Hat"
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.0
-IMAGE_TAG ?= 1.1.0
-REDUCED_VERSION ?= 1.1.0-snapshot
+VERSION ?= 1.1.1
+IMAGE_TAG ?= 1.1.1
+REDUCED_VERSION ?= 1.1.1-snapshot
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -12,8 +12,8 @@ LABEL maintainer="Red Hat"
 LABEL vendor="Red Hat, Inc."
 LABEL distribution-scope="public"
 LABEL url="https://www.redhat.com"
-LABEL version="1.1.0"
-LABEL release=1.1.0
+LABEL version="1.1.1"
+LABEL release=1.1.1
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -111,7 +111,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/trustification/trusted-profile-analyzer-operator
     support: Red Hat
-  name: rhtpa-operator.v1.1.0
+  name: rhtpa-operator.v1.1.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -373,4 +373,4 @@ spec:
   relatedImages:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:af3ec8405bdb4fea5462129d2519a6c90d0c106612a1ef038c0ee108b89b9533
       name: manager
-  version: 1.1.0
+  version: 1.1.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: registry.redhat.io/rhtpa/rhtpa-rhel9-operator
-  newTag: 1.1.0
+  newTag: 1.1.1

--- a/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
@@ -71,4 +71,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/trustification/trusted-profile-analyzer-operator
-  version: 1.1.0
+  version: 1.1.1

--- a/devel/README.md
+++ b/devel/README.md
@@ -52,7 +52,7 @@ update the operator sha and then run
 ```console
   make bundle-build
   make bundle-push
-  operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel9-operator-bundle:v1.1.0
+  operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel9-operator-bundle:v1.1.1
 ```
 
 # Deploy an instance


### PR DESCRIPTION
## Summary by Sourcery

Bump the operator, bundle, and image metadata to version 1.1.1 across build, deployment, and manifest configuration.

Build:
- Update Makefile defaults and container image labels to use version 1.1.1.

Deployment:
- Align Tekton pipeline params, kustomize manager image tag, and ClusterServiceVersion manifests with operator version 1.1.1.

Documentation:
- Refresh development README example commands to reference the 1.1.1 bundle tag.