### PR TITLE
Update again konflux

### DIFF
--- a/.tekton/operator-1-1-z-pull-request.yaml
+++ b/.tekton/operator-1-1-z-pull-request.yaml
@@ -233,7 +233,7 @@ spec:
             - name: name
               value: buildah-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:06caee8bb4eb9e525ff60e816bffb5c895b6a2db454faf0fb2e1066145fe43a6
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -235,7 +235,7 @@ spec:
             - name: name
               value: buildah-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:06caee8bb4eb9e525ff60e816bffb5c895b6a2db454faf0fb2e1066145fe43a6
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/operator-bundle-1-1-z-pull-request.yaml
+++ b/.tekton/operator-bundle-1-1-z-pull-request.yaml
@@ -229,7 +229,7 @@ spec:
             - name: name
               value: buildah-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:06caee8bb4eb9e525ff60e816bffb5c895b6a2db454faf0fb2e1066145fe43a6
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -234,7 +234,7 @@ spec:
             - name: name
               value: buildah-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.6@sha256:06caee8bb4eb9e525ff60e816bffb5c895b6a2db454faf0fb2e1066145fe43a6
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump buildah-oci-ta Tekton task bundle from version 0.6 to 0.7 across operator 1-1-z and operator-bundle 1-1-z pull-request and push pipelines.