### PR TITLE
Removed SOURCE_DATE_EPOCH to receive the label from the buildah task

### DIFF
--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -44,7 +44,6 @@ LABEL version="1.1.1"
 LABEL release=1.1.1
 LABEL maintainer="Red Hat"
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
-LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,6 @@ LABEL url="https://www.redhat.com"
 LABEL version="1.1.1"
 LABEL release=1.1.1
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
-LABEL org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"


### PR DESCRIPTION
Removed SOURCE_DATE_EPOCH from the container files to receive the label from the buildah task automatically

## Summary by Sourcery

Enhancements:
- Stop setting org.opencontainers.image.created in container metadata so it can be sourced from the buildah task instead.