### PR TITLE
Label for olmv1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ LABEL summary="RHTPA Operator"
 LABEL version="1.1.1"
 LABEL release=1.1.1
 LABEL maintainer="Red Hat"
+LABEL operators.operatorframework.io.index.configs.v1=/config
 
 RUN microdnf update -y && microdnf clean all -y
 

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -63,6 +63,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1=stable,stable-v1.0,stabl
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
+LABEL operators.operatorframework.io.index.configs.v1=/config
 LABEL operators.openshift.io/valid-subscription="Red Hat Trusted Profile Analyzer"
 
 RUN microdnf update -y && microdnf clean all -y

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,6 +36,7 @@ LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1.1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
+LABEL operators.operatorframework.io.index.configs.v1=/config
 LABEL operators.openshift.io/valid-subscription="Red Hat Trusted Profile Analyzer"
 
 # Labels for testing.


### PR DESCRIPTION
Label for olmv1

## Summary by Sourcery

Enhancements:
- Annotate bundle and main operator images with the operators.operatorframework.io.index.configs.v1 label pointing to the /config directory.