### PR TITLE
UBI10 for 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL com.redhat.component="rhtpa-operator"
 LABEL description="Red Hat Trusted Profile Analyzer Operator"

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -1,5 +1,5 @@
-# Build the manager binary 9.7-1769430014 1.25.5-1769430014
-FROM registry.access.redhat.com/ubi10/go-toolset@sha256:359dd4c6c4255b3f7bce4dc15ffa5a9aa65a401f819048466fa91baa8244a793 AS builder
+# Build the manager binary 10.1-1770726582 1.25.5-1770726582
+FROM registry.access.redhat.com/ubi10/go-toolset@sha256:1edf7bd8e7175ec53a5eefb4e0008adfe30cb7b5ad6834ed7eeef1df9f1920dd AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -1,5 +1,5 @@
 # Build the manager binary 9.7-1769430014 1.25.5-1769430014
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:359dd4c6c4255b3f7bce4dc15ffa5a9aa65a401f819048466fa91baa8244a793 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset@sha256:359dd4c6c4255b3f7bce4dc15ffa5a9aa65a401f819048466fa91baa8244a793 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=rea
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL com.redhat.component="rhtpa-operator"
 LABEL description="Red Hat Trusted Profile Analyzer Operator"

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -42,7 +42,7 @@ LABEL summary="RHTPA Operator"
 LABEL version="1.1.1"
 LABEL release=1.1.1
 LABEL maintainer="Red Hat"
-LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
+LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.3::el10"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -14,7 +14,7 @@ LABEL distribution-scope="public"
 LABEL url="https://www.redhat.com"
 LABEL version="1.1.1"
 LABEL release=1.1.1
-LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
+LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el10"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/tests/test-server-connection.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/tests/test-server-connection.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      image: registry.access.redhat.com/ubi10/ubi-minimal:latest
       command: ["sh", "-c"]
       args:
         - |


### PR DESCRIPTION
## Summary by Sourcery

Update container images and metadata to target UBI 10.

Build:
- Switch operator and test container base images from UBI 9 minimal to UBI 10 minimal.
- Update bundle CPE label to reference the UBI 10 (el10) platform.