### PR TITLE
Restore OwnNamespace

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -348,7 +348,7 @@ spec:
           serviceAccountName: rhtpa-operator-controller-manager
     strategy: deployment
   installModes:
-    - supported: false
+    - supported: true
       type: OwnNamespace
     - supported: true
       type: SingleNamespace

--- a/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-    - supported: false
+    - supported: true
       type: OwnNamespace
     - supported: true
       type: SingleNamespace


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow deploying the rhtpa-operator using the OwnNamespace install mode in CSV bundle and base manifests.