### PR TITLE
Fix image hash and restore tag

### DIFF
--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -515,6 +515,8 @@ spec:
             value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
             value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: ADDITIONAL_TAGS
+            value: ['$(params.version)$(params.version-postfix-qe)', '{{revision}}']
         runAfter:
           - build-image-index
         taskRef:

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:12fc05a3ad97de8f5a20615343ca03544536a263d580112414f4aa00a375abe96
+  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:12fc05a3ad97de8f5a20615343ca03544536a263d580112414f4aa00a375abe9
   pullPolicy: IfNotPresent
 
 rust: {}


### PR DESCRIPTION
## Summary by Sourcery

Update image publishing configuration and correct the deployed image reference.

Bug Fixes:
- Correct the container image digest in the Helm chart values to point to the intended image artifact.

Enhancements:
- Pass additional image tags (version with postfix and revision) to the image index publishing task in the Tekton pipeline for richer tagging of published images.