### PR TITLE
Update importers

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -84,9 +84,9 @@ modules:
         sbom:
           description: All Red Hat SBOMs
           period: 1d
-          source: https://access.redhat.com/security/data/sbom/beta/
+          source: https://security.access.redhat.com/data/sbom/v1/
           keys:
-            - https://access.redhat.com/security/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4
+            - https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4
           disabled: true
           fetchRetries: 50
       redhat-csaf:


### PR DESCRIPTION
Update importers configuration
## Summary by Sourcery

Bug Fixes:
- Point the SBOM source and key URLs to the current Red Hat security data endpoints to ensure SBOM imports use the updated service.