### PR TITLE
Bump 1.1.3

### DIFF
--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
     - name: version
-      value: "v1.1.2"
+      value: "v1.1.3"
     - name: version-postfix-qe
       value: "-rc"
     - name: git-url

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
     - name: version
-      value: "v1.1.2"
+      value: "v1.1.3"
     - name: version-postfix-qe
       value: "-rc"
     - name: git-url

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer
 LABEL name="rhtpa/rhtpa-rhel9-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="1.1.1"
-LABEL release=1.1.1
+LABEL version="1.1.3"
+LABEL release=1.1.3
 LABEL maintainer="Red Hat"
 LABEL operators.operatorframework.io.index.configs.v1=/config
 

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -39,8 +39,8 @@ LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer
 LABEL name="rhtpa/rhtpa-rhel9-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="1.1.2"
-LABEL release=1.1.2
+LABEL version="1.1.3"
+LABEL release=1.1.3
 LABEL maintainer="Red Hat"
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.1
-IMAGE_TAG ?= 1.1.1
-REDUCED_VERSION ?= 1.1.1-snapshot
+VERSION ?= 1.1.3
+IMAGE_TAG ?= 1.1.3
+REDUCED_VERSION ?= 1.1.3-snapshot
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -12,8 +12,8 @@ LABEL maintainer="Red Hat"
 LABEL vendor="Red Hat, Inc."
 LABEL distribution-scope="public"
 LABEL url="https://www.redhat.com"
-LABEL version="1.1.2"
-LABEL release=1.1.2
+LABEL version="1.1.3"
+LABEL release=1.1.3
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 
 LABEL features.operators.openshift.io/cni="false"

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -111,7 +111,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/trustification/trusted-profile-analyzer-operator
     support: Red Hat
-  name: rhtpa-operator.v1.1.2
+  name: rhtpa-operator.v1.1.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -373,4 +373,4 @@ spec:
   relatedImages:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:9db50052057ad4ec94099bc3c9ab476f5ac7b00954c99cb0b26fe729abba3387
       name: manager
-  version: 1.1.2
+  version: 1.1.3

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: registry.redhat.io/rhtpa/rhtpa-rhel9-operator
-  newTag: 1.1.2
+  newTag: 1.1.3

--- a/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
@@ -71,4 +71,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/trustification/trusted-profile-analyzer-operator
-  version: 1.1.2
+  version: 1.1.3

--- a/devel/README.md
+++ b/devel/README.md
@@ -52,7 +52,7 @@ update the operator sha and then run
 ```console
   make bundle-build
   make bundle-push
-  operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel9-operator-bundle:v1.1.2
+  operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel9-operator-bundle:v1.1.3
 ```
 
 # Deploy an instance


### PR DESCRIPTION
## Summary by Sourcery

Bump the operator and bundle version metadata to 1.1.3 across build, deployment, and release artifacts.

Build:
- Update Makefile defaults and container image labels to version 1.1.3 for the operator and bundle images.

CI:
- Update Tekton pipeline parameters to push and test version v1.1.3 operator and bundle releases.

Deployment:
- Update kustomize and ClusterServiceVersion manifests to reference operator image and version 1.1.3.

Documentation:
- Refresh development README example commands to use the v1.1.3 bundle tag.