### PR TITLE
[DRAFT-WIP] TLS1.3

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -149,6 +149,54 @@ spec:
       clusterPermissions:
         - rules:
             - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - ingresses
+                - clusterversions
+              verbs:
+                - get
+                - list
+                - watch
+                - patch
+                - update
+            - apiGroups:
                 - networking.k8s.io
               resources:
                 - ingresses

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -15,6 +15,10 @@ resources:
 - rolebinding_job.yaml
 - role_cluster_ingress.yaml
 - role_cluster_ingress_binding.yaml
+- role_cluster_tlsconfigurator.yaml
+- role_binding_tlsconfigurator.yaml
+- role_cluster_rbac_manager.yaml
+- role_cluster_rbac_manager_binding.yaml
 # The following RBAC configurations are used to protect
 # the metrics endpoint with authn/authz. These configurations
 # ensure that only authorized users and service accounts

--- a/config/rbac/role_binding_tlsconfigurator.yaml
+++ b/config/rbac/role_binding_tlsconfigurator.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-configurator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-configurator
+subjects:
+  - kind: ServiceAccount
+    name: tls-configurator
+    namespace: openshift-ingress-operator

--- a/config/rbac/role_cluster_rbac_manager.yaml
+++ b/config/rbac/role_cluster_rbac_manager.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhtpa-rbac-manager
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch", "update"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch", "update"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch", "update"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["ingresses", "clusterversions"]
+  verbs: ["get", "list", "watch", "patch", "update"]

--- a/config/rbac/role_cluster_rbac_manager_binding.yaml
+++ b/config/rbac/role_cluster_rbac_manager_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhtpa-rbac-manager
+subjects:
+- kind: ServiceAccount
+  name: rhtpa-operator-controller-manager
+  namespace: placeholder
+roleRef:
+  kind: ClusterRole
+  name: rhtpa-rbac-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role_cluster_tlsconfigurator.yaml
+++ b/config/rbac/role_cluster_tlsconfigurator.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-configurator
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["ingresses", "clusterversions"]
+  verbs: ["get", "list", "watch", "patch", "update"]

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -6,3 +6,12 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: rhtpa-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: tls-configurator
+  namespace: openshift-ingress-operator

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/010-ServiceAccount.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/010-ServiceAccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.modules.tlsConfigurator.enabled }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tls-configurator
+  namespace: openshift-ingress-operator
+  labels:
+    app.kubernetes.io/name: tls-configurator
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+    helm.sh/hook-weight: "10"
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: before-hook-creation
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/015-ClusterRole.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/015-ClusterRole.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.modules.tlsConfigurator.enabled }}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-configurator
+  labels:
+    app.kubernetes.io/name: tls-configurator
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "2"
+    helm.sh/hook-weight: "15"
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["ingresses", "clusterversions"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/018-ClusterRoleBinding.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/018-ClusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.modules.tlsConfigurator.enabled }}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-configurator
+  labels:
+    app.kubernetes.io/name: tls-configurator
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "2"
+    helm.sh/hook-weight: "18"
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-configurator
+subjects:
+  - kind: ServiceAccount
+    name: tls-configurator
+    namespace: openshift-ingress-operator
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/tls-configure/020-Job.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.modules.tlsConfigurator.enabled }}
+
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: tls-configurator
+  namespace: openshift-ingress-operator
+  labels:
+    app.kubernetes.io/name: tls-configurator
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "3"
+    helm.sh/hook-weight: "20"
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: before-hook-creation
+
+spec:
+  backoffLimit: 10
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 600
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tls-configurator
+    spec:
+      serviceAccountName: tls-configurator
+      containers:
+        - name: tls-configurator
+          image: {{ .Values.modules.tlsConfigurator.image.fullName }}
+          args:
+            - "--action=update"
+            - "--type=Custom"
+            - "--min-tls-version=VersionTLS13"
+            - "--ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"
+      restartPolicy: OnFailure
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -352,6 +352,20 @@
               }
             }
           ]
+        },
+        "tlsConfigurator": {
+          "description": "TLS Configuragtor for Openshift\n",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Feature"
+            },
+            {
+              "$ref": "#/definitions/Image"
+            },
+            {
+              "$ref": "#/definitions/Application"
+            }
+          ]
         }
       }
     },

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -254,6 +254,14 @@ properties:
           - $ref: "#/definitions/Image"
           - $ref: "#/definitions/Application"
 
+      tlsConfigurator:
+        description: |
+          TLS Configurator for Openshift
+        allOf:
+          - $ref: "#/definitions/Feature"
+          - $ref: "#/definitions/Image"
+          - $ref: "#/definitions/Application"
+
       createImporters:
         description: |
           Job to create a set of pre-defined importers

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -116,3 +116,10 @@ modules:
           source: quay.io
           namespace: redhat-user-workloads
           disabled: true
+
+  tlsConfigurator:
+    enabled: false
+    name: tls-configurator
+    image:
+      fullName: quay.io/mdessi/tls-configurator:latest
+      pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary by Sourcery

Introduce a TLS configurator capability and supporting RBAC to manage OpenShift ingress TLS settings, and update build tooling.

New Features:
- Add an optional tlsConfigurator module and Kubernetes Job to configure OpenShift ingress TLS settings (e.g., TLS 1.3) during installation/upgrade.

Enhancements:
- Extend operator cluster permissions and introduce dedicated rhtpa-rbac-manager and tls-configurator ClusterRoles/ClusterRoleBindings to manage service accounts, jobs, RBAC objects, and OpenShift ingress/clusterversion resources.
- Update Helm values and schema to expose configuration for the tlsConfigurator component, disabled by default.

Build:
- Bump the Go toolchain patch version used in the operator Dockerfile builder stage.