### PR TITLE
Bump golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.7 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -1,5 +1,5 @@
 # Build the manager binary 9.7-1769430014 1.25.5-1769430014
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:359dd4c6c4255b3f7bce4dc15ffa5a9aa65a401f819048466fa91baa8244a793 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the golang builder base image from version 1.25.5 to 1.25.7 in the Dockerfile.