### PR TITLE
UBI10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL com.redhat.component="rhtpa-operator"
 LABEL description="Red Hat Trusted Profile Analyzer Operator"

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:9.7-1773851748 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset:10.1 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=rea
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL com.redhat.component="rhtpa-operator"
 LABEL description="Red Hat Trusted Profile Analyzer Operator"

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/tests/test-server-connection.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/tests/test-server-connection.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      image: registry.access.redhat.com/ubi10/ubi-minimal:latest
       command: ["sh", "-c"]
       args:
         - |


### PR DESCRIPTION
UBI 10

## Summary by Sourcery

Update container base images to use UBI 10 minimal instead of UBI 9 for the operator and its Helm test resources.

Build:
- Switch the operator Dockerfile base image from ubi9/ubi-minimal to ubi10/ubi-minimal.

Tests:
- Update Helm chart test container image to use ubi10/ubi-minimal instead of ubi9/ubi-minimal.