### PR TITLE
2.2.4

### DIFF
--- a/.tekton/operator-1-1-z-push.yaml
+++ b/.tekton/operator-1-1-z-push.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   params:
     - name: version
-      value: "v1.1.3"
+      value: "v1.1.4"
     - name: version-postfix-qe
       value: "-rc"
     - name: git-url

--- a/.tekton/operator-bundle-1-1-z-push.yaml
+++ b/.tekton/operator-bundle-1-1-z-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
     - name: version
-      value: "v1.1.3"
+      value: "v1.1.4"
     - name: version-postfix-qe
       value: "-rc"
     - name: git-url

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.7 AS builder
+FROM golang:1.25.8 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -1,5 +1,5 @@
-# Build the manager binary 9.7-1769430014 1.25.5-1769430014
-FROM registry.access.redhat.com/ubi9/go-toolset:9.7-1773851748 AS builder
+# Build the manager binary 1.25.8
+FROM registry.redhat.io/ubi9/go-toolset@sha256:4b7a967ce9c283ecfb1e7a186f7b97d3f35a479bcc38d3c03a0707f3c36e974d AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -39,8 +39,8 @@ LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer
 LABEL name="rhtpa/rhtpa-rhel9-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="1.1.3"
-LABEL release=1.1.3
+LABEL version="1.1.4"
+LABEL release=1.1.4
 LABEL maintainer="Red Hat"
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.3
-IMAGE_TAG ?= 1.1.3
-REDUCED_VERSION ?= 1.1.3-snapshot
+VERSION ?= 1.1.4
+IMAGE_TAG ?= 1.1.4
+REDUCED_VERSION ?= 1.1.4-snapshot
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -12,8 +12,8 @@ LABEL maintainer="Red Hat"
 LABEL vendor="Red Hat, Inc."
 LABEL distribution-scope="public"
 LABEL url="https://www.redhat.com"
-LABEL version="1.1.3"
-LABEL release=1.1.3
+LABEL version="1.1.4"
+LABEL release=1.1.4
 LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:2.2::el9"
 
 LABEL features.operators.openshift.io/cni="false"

--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -111,7 +111,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/trustification/trusted-profile-analyzer-operator
     support: Red Hat
-  name: rhtpa-operator.v1.1.3
+  name: rhtpa-operator.v1.1.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -373,4 +373,4 @@ spec:
   relatedImages:
     - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:cb5b933220b1493a9fd73380d296b3d6f79c594fc28446e0197c9a3b143025ef
       name: manager
-  version: 1.1.3
+  version: 1.1.4

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: registry.redhat.io/rhtpa/rhtpa-rhel9-operator
-  newTag: 1.1.3
+  newTag: 1.1.4

--- a/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtpa-operator.clusterserviceversion.yaml
@@ -71,4 +71,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/trustification/trusted-profile-analyzer-operator
-  version: 1.1.3
+  version: 1.1.4

--- a/devel/README.md
+++ b/devel/README.md
@@ -52,7 +52,7 @@ update the operator sha and then run
 ```console
   make bundle-build
   make bundle-push
-  operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel9-operator-bundle:v1.1.3
+  operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel9-operator-bundle:v1.1.4
 ```
 
 # Deploy an instance


### PR DESCRIPTION
2.2.4 preparation and go 1.25.8 update

## Summary by Sourcery

Prepare release 1.1.4 of the rhtpa operator by updating version metadata and image tags across build, bundle, and deployment assets.

Build:
- Bump default operator version, image tag, and snapshot version in the Makefile.
- Update bundle Dockerfile labels to reference operator version 1.1.4.

CI:
- Adjust Tekton pipeline parameters to build and push the 1.1.4 operator and bundle images.

Deployment:
- Update operator image tag and ClusterServiceVersion names/versions in manifests and kustomize configuration to 1.1.4.

Documentation:
- Refresh development README example command to use the 1.1.4 bundle tag.