### PR TITLE
OIDC use UI_SCOPE env var and 2.2.4 image

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_oidc.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_oidc.tpl
@@ -28,10 +28,18 @@ Arguments: (dict)
 UI scopes passed to the backend for the frontend client.
 Arguments: .
 */}}
-{{- define "trustification.oidc.uiScopes" -}}
-{{- if .Values.oidc.uiScopes -}}
-{{- .Values.oidc.uiScopes -}}
+{{- define "trustification.oidc.uiScope" -}}
+{{- if .Values.oidc.uiScope -}}
+{{- .Values.oidc.uiScope -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+OIDC user Info boolean.
+Arguments: .
+*/}}
+{{- define "trustification.oidc.userInfo" -}}
+{{- .Values.oidc.userInfo | default true -}}
 {{- end -}}
 
 {{/*

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
@@ -57,8 +57,10 @@ spec:
               value: {{ include "trustification.oidc.frontendIssuerUrl" . }}
             - name: UI_CLIENT_ID
               value: {{ include "trustification.oidc.frontendClientId" . }}
-            {{- with (include "trustification.oidc.uiScopes" . | trim) }}
-            - name: UI_SCOPES
+            - name: OIDC_USER_INFO
+              value: {{ include "trustification.oidc.userInfo" . }}
+            {{- with (include "trustification.oidc.uiScope" . | trim) }}
+            - name: UI_SCOPE
               value: {{ . | quote }}
             {{- end }}
 

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -377,9 +377,6 @@
     "keycloak": {
       "$ref": "#/definitions/Feature"
     },
-    "keycloakPostInstall": {
-      "$ref": "#/definitions/Feature"
-    },
     "postgresql": {
       "$ref": "#/definitions/Feature"
     },
@@ -742,9 +739,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "uiScopes": {
+        "uiScope": {
           "type": "string",
-          "description": "Optional value for the `UI_SCOPES` environment variable in the server deployment.\n"
+          "description": "Optional value for the `UI_SCOPE` environment variable in the server deployment.\n"
         },
         "issuerUrl": {
           "$ref": "#/definitions/ValueOrRef"
@@ -753,6 +750,11 @@
           "type": "boolean",
           "description": "Use insecure TLS when communicating with the issuer (DANGER!)\n",
           "default": false
+        },
+        "userInfo": {
+          "type": "boolean",
+          "description": "Value for the `OIDC_USER_INFO` boolean environment variable in the server deployment.\n",
+          "default": true
         },
         "clients": {
           "properties": {

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -290,9 +290,6 @@ properties:
   keycloak:
     $ref: "#/definitions/Feature"
 
-  keycloakPostInstall:
-    $ref: "#/definitions/Feature"
-
   postgresql:
     $ref: "#/definitions/Feature"
 
@@ -568,10 +565,10 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      uiScopes:
+      uiScope:
         type: string
         description: |
-          Optional value for the `UI_SCOPES` environment variable in the server deployment.
+          Optional value for the `UI_SCOPE` environment variable in the server deployment.
 
       issuerUrl:
         $ref: "#/definitions/ValueOrRef"
@@ -581,6 +578,12 @@ definitions:
         description: |
           Use insecure TLS when communicating with the issuer (DANGER!)
         default: false
+
+      userInfo:
+        type: boolean
+        description: |
+          Value for the `OIDC_USER_INFO` environment variable in the server deployment
+        default: true
 
       clients:
         properties:

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:7e8f7bc3d6ac60f987cc21f275f9430665af7755659bd399f3013ee661c3bdd0
+  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:e0258ffff3e5b96730d1207a127599c7e6ba7b2a1914c80f6af1accb4d5d31ab
   pullPolicy: IfNotPresent
 
 rust: {}
@@ -21,7 +21,7 @@ openshift:
   useServiceCa: true
 
 oidc:
-  uiScopes: ""
+  uiScope: ""
   clients:
     frontend: {}
     cli:


### PR DESCRIPTION
OIDC use UI_SCOPE env var and 2.2.4 image


## Summary by Sourcery

Align OIDC Helm chart configuration and deployment with new UI_SCOPE and OIDC_USER_INFO environment variables.

New Features:
- Expose a configurable OIDC_USER_INFO flag for the server via Helm values and deployment env vars.

Enhancements:
- Rename the OIDC UI scopes configuration from uiScopes to uiScope and wire it to the UI_SCOPE environment variable.
- Clean up Helm values schema by removing the unused keycloakPostInstall feature configuration.