### PR TITLE
Update image for rhtpa 2.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer
 LABEL name="rhtpa/rhtpa-rhel9-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="1.1.3"
-LABEL release=1.1.3
+LABEL version="1.1.4"
+LABEL release=1.1.4
 LABEL maintainer="Red Hat"
 LABEL operators.operatorframework.io.index.configs.v1=/config
 

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:e0258ffff3e5b96730d1207a127599c7e6ba7b2a1914c80f6af1accb4d5d31ab
+  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:c1fd3736f86667698e06b4b2fed5407867dd89dbe53f8e97a9aa23a87ce12909
   pullPolicy: IfNotPresent
 
 rust: {}


### PR DESCRIPTION
Update image for rhtpa 2.2.4

## Summary by Sourcery

Bump the RHTPA operator and service image versions to align with the 1.1.4 / rhtpa 2.2.4 release.

Enhancements:
- Update container image digest for the trusted profile analyzer service in Helm chart values.

Build:
- Update Docker image version and release labels to 1.1.4.