### PR TITLE
Enable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: make test-ci
 
       - name: Upload coverage
-        if: always()
+        if: always() && hashFiles('cover.out') != ''
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify generated code is up-to-date
+        run: |
+          make manifests generate
+          if ! git diff --quiet; then
+            echo "::error::Generated code is out of date. Run 'make manifests generate' and commit the changes."
+            git diff
+            exit 1
+          fi
+
+      - name: Run tests
+        run: make test-ci
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: cover.out
+          retention-days: 7
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify build
+        run: go build -o /dev/null .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
 
   build:
     name: Build
+    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions CI workflow to lint, test, and build the Go project on pushes and pull requests to main and release branches.

CI:
- Introduce a CI workflow that runs Go vet and golangci-lint on pull requests and pushes to main and release branches.
- Add a test job that verifies generated code, runs the test suite, and uploads coverage artifacts.
- Add a build job that verifies the project builds successfully using the configured Go toolchain.