### PR TITLE
[TC-4177] Part-B

### DIFF
--- a/test/integration/crd_test.go
+++ b/test/integration/crd_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// CRD represents a CustomResourceDefinition
+type CRD struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Group string `yaml:"group"`
+		Names struct {
+			Kind       string   `yaml:"kind"`
+			ListKind   string   `yaml:"listKind"`
+			Plural     string   `yaml:"plural"`
+			Singular   string   `yaml:"singular"`
+			ShortNames []string `yaml:"shortNames"`
+		} `yaml:"names"`
+		Scope    string `yaml:"scope"`
+		Versions []struct {
+			Name    string `yaml:"name"`
+			Served  bool   `yaml:"served"`
+			Storage bool   `yaml:"storage"`
+		} `yaml:"versions"`
+	} `yaml:"spec"`
+}
+
+func TestCRDExists(t *testing.T) {
+	crdPath := filepath.Join("config", "crd", "bases", "rhtpa.io_trustedprofileanalyzers.yaml")
+
+	_, err := os.Stat(crdPath)
+	require.NoError(t, err, "CRD file should exist")
+}
+
+func TestCRDValid(t *testing.T) {
+	crdPath := filepath.Join("config", "crd", "bases", "rhtpa.io_trustedprofileanalyzers.yaml")
+
+	data, err := os.ReadFile(crdPath)
+	require.NoError(t, err, "CRD should be readable")
+
+	var crd CRD
+	err = yaml.Unmarshal(data, &crd)
+	require.NoError(t, err, "CRD should be valid YAML")
+
+	// Validate CRD metadata
+	assert.Equal(t, "apiextensions.k8s.io/v1", crd.APIVersion, "CRD API version should be v1")
+	assert.Equal(t, "CustomResourceDefinition", crd.Kind, "Kind should be CustomResourceDefinition")
+	assert.Equal(t, "trustedprofileanalyzers.rhtpa.io", crd.Metadata.Name, "CRD name should be correct")
+
+	// Validate spec
+	assert.Equal(t, "rhtpa.io", crd.Spec.Group, "Group should be rhtpa.io")
+	assert.Equal(t, "TrustedProfileAnalyzer", crd.Spec.Names.Kind, "Kind should be TrustedProfileAnalyzer")
+	assert.Equal(t, "TrustedProfileAnalyzerList", crd.Spec.Names.ListKind, "ListKind should be correct")
+	assert.Equal(t, "trustedprofileanalyzers", crd.Spec.Names.Plural, "Plural should be correct")
+	assert.Equal(t, "trustedprofileanalyzer", crd.Spec.Names.Singular, "Singular should be correct")
+	assert.Contains(t, crd.Spec.Names.ShortNames, "rhtpa", "ShortNames should include rhtpa")
+	assert.Equal(t, "Namespaced", crd.Spec.Scope, "Scope should be Namespaced")
+
+	// Validate versions
+	require.NotEmpty(t, crd.Spec.Versions, "CRD should have versions")
+
+	v1Found := false
+	storageVersionFound := false
+
+	for _, version := range crd.Spec.Versions {
+		if version.Name == "v1" {
+			v1Found = true
+			assert.True(t, version.Served, "v1 should be served")
+			if version.Storage {
+				storageVersionFound = true
+			}
+		}
+	}
+
+	assert.True(t, v1Found, "v1 version should exist")
+	assert.True(t, storageVersionFound, "One version should be storage version")
+}
+
+func TestSampleCRsValid(t *testing.T) {
+	samplesPath := filepath.Join("config", "samples")
+
+	samples, err := os.ReadDir(samplesPath)
+	require.NoError(t, err, "samples directory should be readable")
+
+	foundSample := false
+	for _, sample := range samples {
+		if sample.IsDir() || filepath.Ext(sample.Name()) != ".yaml" {
+			continue
+		}
+
+		if sample.Name() == "kustomization.yaml" {
+			continue
+		}
+
+		foundSample = true
+		samplePath := filepath.Join(samplesPath, sample.Name())
+
+		data, err := os.ReadFile(samplePath)
+		require.NoError(t, err, "sample %s should be readable", sample.Name())
+
+		var cr map[string]interface{}
+		err = yaml.Unmarshal(data, &cr)
+		require.NoError(t, err, "sample %s should be valid YAML", sample.Name())
+
+		// Validate basic CR structure
+		assert.Equal(t, "rhtpa.io/v1", cr["apiVersion"], "sample should have correct apiVersion")
+		assert.Equal(t, "TrustedProfileAnalyzer", cr["kind"], "sample should have correct kind")
+		assert.NotNil(t, cr["metadata"], "sample should have metadata")
+		assert.NotNil(t, cr["spec"], "sample should have spec")
+	}
+
+	assert.True(t, foundSample, "at least one sample CR should exist")
+}

--- a/test/integration/helm_chart_test.go
+++ b/test/integration/helm_chart_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// ChartYaml represents the Chart.yaml structure
+type ChartYaml struct {
+	APIVersion  string `yaml:"apiVersion"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Type        string `yaml:"type"`
+	Version     string `yaml:"version"`
+	AppVersion  string `yaml:"appVersion"`
+	KubeVersion string `yaml:"kubeVersion"`
+	Maintainers []struct {
+		Name  string `yaml:"name"`
+		URL   string `yaml:"url"`
+		Email string `yaml:"email"`
+	} `yaml:"maintainers"`
+}
+
+// ValuesYaml represents a subset of the values.yaml structure
+type ValuesYaml struct {
+	AppDomain string `yaml:"appDomain"`
+	PartOf    string `yaml:"partOf"`
+	Replicas  int    `yaml:"replicas"`
+	Modules   struct {
+		Server struct {
+			Enabled  bool `yaml:"enabled"`
+			Replicas int  `yaml:"replicas"`
+		} `yaml:"server"`
+		Importer struct {
+			Enabled  bool `yaml:"enabled"`
+			Replicas int  `yaml:"replicas"`
+		} `yaml:"importer"`
+	} `yaml:"modules"`
+}
+
+func TestChartYamlValid(t *testing.T) {
+	chartPath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", "Chart.yaml")
+
+	data, err := os.ReadFile(chartPath)
+	require.NoError(t, err, "Chart.yaml should be readable")
+
+	var chart ChartYaml
+	err = yaml.Unmarshal(data, &chart)
+	require.NoError(t, err, "Chart.yaml should be valid YAML")
+
+	// Validate required fields
+	assert.Equal(t, "v2", chart.APIVersion, "Chart API version should be v2")
+	assert.Equal(t, "redhat-trusted-profile-analyzer", chart.Name, "Chart name should match")
+	assert.Equal(t, "application", chart.Type, "Chart type should be application")
+	assert.NotEmpty(t, chart.Version, "Chart version should be set")
+	assert.NotEmpty(t, chart.AppVersion, "App version should be set")
+	assert.NotEmpty(t, chart.KubeVersion, "Kubernetes version should be specified")
+	assert.NotEmpty(t, chart.Maintainers, "Maintainers should be specified")
+}
+
+func TestValuesYamlValid(t *testing.T) {
+	valuesPath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", "values.yaml")
+
+	data, err := os.ReadFile(valuesPath)
+	require.NoError(t, err, "values.yaml should be readable")
+
+	var values ValuesYaml
+	err = yaml.Unmarshal(data, &values)
+	require.NoError(t, err, "values.yaml should be valid YAML")
+
+	// Validate default values
+	assert.Equal(t, "change-me", values.AppDomain, "appDomain should have placeholder")
+	assert.Equal(t, "trustify", values.PartOf, "partOf should be trustify")
+	assert.Equal(t, 1, values.Replicas, "default replicas should be 1")
+
+	// Validate module defaults
+	assert.True(t, values.Modules.Server.Enabled, "server module should be enabled by default")
+	assert.True(t, values.Modules.Importer.Enabled, "importer module should be enabled by default")
+}
+
+func TestValuesSchemaExists(t *testing.T) {
+	schemaPath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", "values.schema.json")
+
+	_, err := os.Stat(schemaPath)
+	assert.NoError(t, err, "values.schema.json should exist")
+
+	// Verify it's valid JSON
+	data, err := os.ReadFile(schemaPath)
+	require.NoError(t, err, "values.schema.json should be readable")
+
+	var schema map[string]interface{}
+	err = yaml.Unmarshal(data, &schema)
+	require.NoError(t, err, "values.schema.json should be valid JSON")
+
+	// Verify required fields are defined
+	properties, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok, "schema should have properties")
+
+	assert.Contains(t, properties, "appDomain", "schema should require appDomain")
+}
+
+func TestHelmTemplateStructure(t *testing.T) {
+	templatesPath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", "templates")
+
+	// Check for required template directories
+	requiredDirs := []string{
+		"services/server",
+		"services/importer",
+		"init/create-database",
+		"init/migrate-database",
+		"init/create-importers",
+		"helpers",
+		"tests",
+	}
+
+	for _, dir := range requiredDirs {
+		dirPath := filepath.Join(templatesPath, dir)
+		info, err := os.Stat(dirPath)
+		require.NoError(t, err, "template directory %s should exist", dir)
+		assert.True(t, info.IsDir(), "%s should be a directory", dir)
+	}
+}
+
+func TestHelmTemplatesExist(t *testing.T) {
+	templatesPath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", "templates")
+
+	// Check for required template files
+	requiredTemplates := []string{
+		"services/server/030-Deployment.yaml",
+		"services/server/040-Service.yaml",
+		"services/server/050-Ingress.yaml",
+		"services/importer/030-Deployment.yaml",
+		"tests/test-server-connection.yaml",
+	}
+
+	for _, template := range requiredTemplates {
+		templatePath := filepath.Join(templatesPath, template)
+		_, err := os.Stat(templatePath)
+		assert.NoError(t, err, "template %s should exist", template)
+	}
+}
+
+func TestHelmNotesExists(t *testing.T) {
+	notesPath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", "templates", "NOTES.txt")
+
+	_, err := os.Stat(notesPath)
+	assert.NoError(t, err, "NOTES.txt should exist")
+
+	data, err := os.ReadFile(notesPath)
+	require.NoError(t, err, "NOTES.txt should be readable")
+	assert.NotEmpty(t, data, "NOTES.txt should not be empty")
+}
+
+func TestHelmIgnoreExists(t *testing.T) {
+	helmignorePath := filepath.Join("helm-charts", "redhat-trusted-profile-analyzer", ".helmignore")
+
+	_, err := os.Stat(helmignorePath)
+	assert.NoError(t, err, ".helmignore should exist")
+}

--- a/test/integration/rbac_test.go
+++ b/test/integration/rbac_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// Role represents a Kubernetes Role
+type Role struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	} `yaml:"metadata"`
+	Rules []struct {
+		APIGroups []string `yaml:"apiGroups"`
+		Resources []string `yaml:"resources"`
+		Verbs     []string `yaml:"verbs"`
+	} `yaml:"rules"`
+}
+
+func TestRBACConfigurationExists(t *testing.T) {
+	rbacPath := filepath.Join("config", "rbac")
+
+	info, err := os.Stat(rbacPath)
+	require.NoError(t, err, "RBAC directory should exist")
+	assert.True(t, info.IsDir(), "RBAC path should be a directory")
+}
+
+func TestManagerRoleExists(t *testing.T) {
+	rolePath := filepath.Join("config", "rbac", "role.yaml")
+
+	data, err := os.ReadFile(rolePath)
+	require.NoError(t, err, "manager role should exist and be readable")
+
+	var role Role
+	err = yaml.Unmarshal(data, &role)
+	require.NoError(t, err, "manager role should be valid YAML")
+
+	assert.Equal(t, "rbac.authorization.k8s.io/v1", role.APIVersion, "role should use correct API version")
+	assert.Contains(t, []string{"Role", "ClusterRole"}, role.Kind, "should be a Role or ClusterRole")
+}
+
+func TestJobRoleConfiguration(t *testing.T) {
+	rolePath := filepath.Join("config", "rbac", "role_job.yaml")
+
+	data, err := os.ReadFile(rolePath)
+	require.NoError(t, err, "job role should exist")
+
+	var role Role
+	err = yaml.Unmarshal(data, &role)
+	require.NoError(t, err, "job role should be valid YAML")
+
+	// Verify job permissions
+	foundJobPermissions := false
+	for _, rule := range role.Rules {
+		if contains(rule.APIGroups, "batch") && contains(rule.Resources, "jobs") {
+			foundJobPermissions = true
+			assert.Contains(t, rule.Verbs, "create", "should be able to create jobs")
+			assert.Contains(t, rule.Verbs, "get", "should be able to get jobs")
+			assert.Contains(t, rule.Verbs, "list", "should be able to list jobs")
+			assert.Contains(t, rule.Verbs, "watch", "should be able to watch jobs")
+		}
+	}
+
+	assert.True(t, foundJobPermissions, "role should have job permissions")
+}
+
+func TestIngressRoleConfiguration(t *testing.T) {
+	rolePath := filepath.Join("config", "rbac", "role_ingress.yaml")
+
+	data, err := os.ReadFile(rolePath)
+	require.NoError(t, err, "ingress role should exist")
+
+	var role Role
+	err = yaml.Unmarshal(data, &role)
+	require.NoError(t, err, "ingress role should be valid YAML")
+
+	// Verify ingress permissions
+	foundIngressPermissions := false
+	for _, rule := range role.Rules {
+		if contains(rule.APIGroups, "networking.k8s.io") && contains(rule.Resources, "ingresses") {
+			foundIngressPermissions = true
+			assert.Contains(t, rule.Verbs, "create", "should be able to create ingresses")
+			assert.Contains(t, rule.Verbs, "get", "should be able to get ingresses")
+		}
+	}
+
+	assert.True(t, foundIngressPermissions, "role should have ingress permissions")
+}
+
+func TestServiceAccountExists(t *testing.T) {
+	saPath := filepath.Join("config", "rbac", "service_account.yaml")
+
+	data, err := os.ReadFile(saPath)
+	require.NoError(t, err, "service account should exist")
+
+	var sa map[string]interface{}
+	err = yaml.Unmarshal(data, &sa)
+	require.NoError(t, err, "service account should be valid YAML")
+
+	assert.Equal(t, "v1", sa["apiVersion"], "service account should use v1 API")
+	assert.Equal(t, "ServiceAccount", sa["kind"], "kind should be ServiceAccount")
+}
+
+func TestLeaderElectionRBAC(t *testing.T) {
+	rolePath := filepath.Join("config", "rbac", "leader_election_role.yaml")
+
+	data, err := os.ReadFile(rolePath)
+	require.NoError(t, err, "leader election role should exist")
+
+	var role Role
+	err = yaml.Unmarshal(data, &role)
+	require.NoError(t, err, "leader election role should be valid YAML")
+
+	// Verify leader election permissions
+	foundLeasePermissions := false
+	for _, rule := range role.Rules {
+		if contains(rule.Resources, "leases") {
+			foundLeasePermissions = true
+			assert.Contains(t, rule.Verbs, "get", "should be able to get leases")
+			assert.Contains(t, rule.Verbs, "create", "should be able to create leases")
+			assert.Contains(t, rule.Verbs, "update", "should be able to update leases")
+		}
+	}
+
+	assert.True(t, foundLeasePermissions, "role should have lease permissions for leader election")
+}
+
+func TestRoleBindingsExist(t *testing.T) {
+	rbacPath := filepath.Join("config", "rbac")
+
+	files, err := os.ReadDir(rbacPath)
+	require.NoError(t, err, "should be able to read RBAC directory")
+
+	foundRoleBinding := false
+	for _, file := range files {
+		if filepath.Ext(file.Name()) == ".yaml" &&
+			(filepath.Base(file.Name()) == "role_binding.yaml" ||
+				filepath.Base(file.Name()) == "rolebinding_job.yaml" ||
+				filepath.Base(file.Name()) == "rolebinding_ingress.yaml") {
+			foundRoleBinding = true
+
+			data, err := os.ReadFile(filepath.Join(rbacPath, file.Name()))
+			require.NoError(t, err, "role binding should be readable: %s", file.Name())
+
+			var rb map[string]interface{}
+			err = yaml.Unmarshal(data, &rb)
+			require.NoError(t, err, "role binding should be valid YAML: %s", file.Name())
+
+			assert.Contains(t, []string{"RoleBinding", "ClusterRoleBinding"}, rb["kind"],
+				"should be a RoleBinding or ClusterRoleBinding: %s", file.Name())
+		}
+	}
+
+	assert.True(t, foundRoleBinding, "at least one role binding should exist")
+}
+
+// Helper function to check if a slice contains a string
+func contains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/security_test.go
+++ b/test/integration/security_test.go
@@ -1,0 +1,467 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type secretMatch struct {
+	File    string
+	Line    int
+	Content string
+}
+
+type allowlistEntry struct {
+	File    string
+	Pattern string
+	Reason  string
+}
+
+var secretAllowlist = []allowlistEntry{}
+
+func findYAMLDocument(t *testing.T, data []byte, kind string) map[string]interface{} {
+	t.Helper()
+	docs := strings.Split(string(data), "\n---\n")
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var obj map[string]interface{}
+		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+			continue
+		}
+		if obj["kind"] == kind {
+			return obj
+		}
+	}
+	return nil
+}
+
+func TestOperatorSecurityContext(t *testing.T) {
+	managerPath := filepath.Join("config", "manager", "manager.yaml")
+
+	data, err := os.ReadFile(managerPath)
+	if err != nil {
+		t.Skip("manager.yaml not found, skipping security context test")
+	}
+
+	// manager.yaml contains multiple YAML documents; find the Deployment
+	deployment := findYAMLDocument(t, data, "Deployment")
+	require.NotNil(t, deployment, "manager.yaml should contain a Deployment")
+
+	// Check for security context
+	spec, ok := deployment["spec"].(map[string]interface{})
+	require.True(t, ok, "deployment should have spec")
+
+	template, ok := spec["template"].(map[string]interface{})
+	require.True(t, ok, "spec should have template")
+
+	templateSpec, ok := template["spec"].(map[string]interface{})
+	if !ok {
+		t.Skip("Template spec not found in expected format")
+	}
+
+	// Check pod security context
+	if securityContext, ok := templateSpec["securityContext"].(map[string]interface{}); ok {
+		t.Logf("Pod security context: %+v", securityContext)
+
+		// Verify runAsNonRoot is set
+		if runAsNonRoot, ok := securityContext["runAsNonRoot"].(bool); ok {
+			assert.True(t, runAsNonRoot, "pod should run as non-root")
+		}
+	}
+
+	// Check container security context
+	containers, ok := templateSpec["containers"].([]interface{})
+	if ok && len(containers) > 0 {
+		for i, container := range containers {
+			containerMap, ok := container.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			if securityContext, ok := containerMap["securityContext"].(map[string]interface{}); ok {
+				t.Logf("Container %d security context: %+v", i, securityContext)
+
+				// Verify common security settings
+				if allowPrivilegeEscalation, ok := securityContext["allowPrivilegeEscalation"].(bool); ok {
+					assert.False(t, allowPrivilegeEscalation, "container should not allow privilege escalation")
+				}
+
+				if runAsNonRoot, ok := securityContext["runAsNonRoot"].(bool); ok {
+					assert.True(t, runAsNonRoot, "container should run as non-root")
+				}
+			}
+		}
+	}
+}
+
+func TestRBACRolesMinimalPrivileges(t *testing.T) {
+	rolePath := filepath.Join("config", "rbac", "role.yaml")
+
+	data, err := os.ReadFile(rolePath)
+	if err != nil {
+		t.Skip("role.yaml not found, skipping RBAC test")
+	}
+
+	// Parse YAML documents (file may contain multiple documents)
+	docs := strings.Split(string(data), "\n---\n")
+
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+
+		var role map[string]interface{}
+		err := yaml.Unmarshal([]byte(doc), &role)
+		if err != nil {
+			t.Logf("Skipping document that couldn't be parsed: %v", err)
+			continue
+		}
+
+		kind, ok := role["kind"].(string)
+		if !ok || (kind != "Role" && kind != "ClusterRole") {
+			continue
+		}
+
+		rules, ok := role["rules"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		t.Logf("Checking %s: %s", kind, role["metadata"].(map[string]interface{})["name"])
+
+		// Check each rule for overly broad permissions
+		for i, rule := range rules {
+			ruleMap, ok := rule.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			// Check for wildcard permissions
+			resources, _ := ruleMap["resources"].([]interface{})
+			verbs, _ := ruleMap["verbs"].([]interface{})
+
+			hasWildcardResource := false
+			hasWildcardVerb := false
+
+			for _, resource := range resources {
+				if resource == "*" {
+					hasWildcardResource = true
+				}
+			}
+
+			for _, verb := range verbs {
+				if verb == "*" {
+					hasWildcardVerb = true
+				}
+			}
+
+			if hasWildcardResource {
+				t.Logf("  Warning: Rule %d has wildcard resource '*'", i)
+			}
+
+			if hasWildcardVerb {
+				t.Logf("  Warning: Rule %d has wildcard verb '*'", i)
+			}
+
+			// Both wildcards together is a security risk
+			if hasWildcardResource && hasWildcardVerb {
+				t.Errorf("  Rule %d has both wildcard resource and verb - overly permissive", i)
+			}
+		}
+	}
+}
+
+func TestServiceAccountAutomountToken(t *testing.T) {
+	saPath := filepath.Join("config", "rbac", "service_account.yaml")
+
+	data, err := os.ReadFile(saPath)
+	if err != nil {
+		t.Skip("service_account.yaml not found, skipping test")
+	}
+
+	var serviceAccount map[string]interface{}
+	err = yaml.Unmarshal(data, &serviceAccount)
+	require.NoError(t, err, "service_account.yaml should be valid YAML")
+
+	// Check if automountServiceAccountToken is explicitly set
+	if automount, ok := serviceAccount["automountServiceAccountToken"].(bool); ok {
+		t.Logf("automountServiceAccountToken is set to: %v", automount)
+		// If set to false, that's good security practice for controllers
+		// If set to true, that's necessary for the operator to function
+		// Either is acceptable, but it should be explicit
+	} else {
+		t.Log("automountServiceAccountToken not explicitly set (will default to true)")
+	}
+}
+
+func TestNetworkPolicyExists(t *testing.T) {
+	npPath := filepath.Join("config", "network-policy")
+
+	info, err := os.Stat(npPath)
+	if err != nil {
+		t.Skip("network-policy directory not found")
+	}
+
+	assert.True(t, info.IsDir(), "network-policy should be a directory")
+
+	// Check for network policy files
+	files, err := os.ReadDir(npPath)
+	require.NoError(t, err, "should be able to read network-policy directory")
+
+	if len(files) > 0 {
+		t.Logf("Found %d network policy file(s)", len(files))
+		for _, file := range files {
+			if !file.IsDir() && strings.HasSuffix(file.Name(), ".yaml") {
+				t.Logf("  - %s", file.Name())
+			}
+		}
+	} else {
+		t.Log("No network policy files found - consider adding network policies for security")
+	}
+}
+
+func TestImagePullPolicySecure(t *testing.T) {
+	managerPath := filepath.Join("config", "manager", "manager.yaml")
+
+	data, err := os.ReadFile(managerPath)
+	if err != nil {
+		t.Skip("manager.yaml not found")
+	}
+
+	deployment := findYAMLDocument(t, data, "Deployment")
+	if deployment == nil {
+		t.Skip("Deployment not found in manager.yaml")
+	}
+
+	spec, ok := deployment["spec"].(map[string]interface{})
+	if !ok {
+		t.Skip("Deployment spec not in expected format")
+	}
+
+	template, ok := spec["template"].(map[string]interface{})
+	if !ok {
+		t.Skip("Template not in expected format")
+	}
+
+	templateSpec, ok := template["spec"].(map[string]interface{})
+	if !ok {
+		t.Skip("Template spec not in expected format")
+	}
+
+	containers, ok := templateSpec["containers"].([]interface{})
+	if !ok || len(containers) == 0 {
+		t.Skip("Containers not found")
+	}
+
+	for i, container := range containers {
+		containerMap, ok := container.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if pullPolicy, ok := containerMap["imagePullPolicy"].(string); ok {
+			t.Logf("Container %d image pull policy: %s", i, pullPolicy)
+
+			// For production, should use IfNotPresent or Always, not Never
+			assert.NotEqual(t, "Never", pullPolicy, "image pull policy should not be Never in production")
+		}
+
+		// Check if using latest tag (not recommended for production)
+		if image, ok := containerMap["image"].(string); ok {
+			if strings.HasSuffix(image, ":latest") {
+				t.Logf("Warning: Container %d uses :latest tag - not recommended for production", i)
+			}
+		}
+	}
+}
+
+func TestResourceLimitsDefined(t *testing.T) {
+	managerPath := filepath.Join("config", "manager", "manager.yaml")
+
+	data, err := os.ReadFile(managerPath)
+	if err != nil {
+		t.Skip("manager.yaml not found")
+	}
+
+	deployment := findYAMLDocument(t, data, "Deployment")
+	if deployment == nil {
+		t.Skip("Deployment not found in manager.yaml")
+	}
+
+	// Navigate to containers
+	spec, _ := deployment["spec"].(map[string]interface{})
+	template, _ := spec["template"].(map[string]interface{})
+	templateSpec, _ := template["spec"].(map[string]interface{})
+	containers, ok := templateSpec["containers"].([]interface{})
+
+	if !ok || len(containers) == 0 {
+		t.Skip("Containers not found in expected format")
+	}
+
+	for i, container := range containers {
+		containerMap, ok := container.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		containerName := "unknown"
+		if name, ok := containerMap["name"].(string); ok {
+			containerName = name
+		}
+
+		resources, ok := containerMap["resources"].(map[string]interface{})
+		if !ok {
+			t.Logf("Warning: Container %s has no resource limits/requests defined", containerName)
+			continue
+		}
+
+		// Check for limits
+		if limits, ok := resources["limits"].(map[string]interface{}); ok {
+			t.Logf("Container %d (%s) has limits: %+v", i, containerName, limits)
+		} else {
+			t.Logf("Warning: Container %s has no resource limits", containerName)
+		}
+
+		// Check for requests
+		if requests, ok := resources["requests"].(map[string]interface{}); ok {
+			t.Logf("Container %d (%s) has requests: %+v", i, containerName, requests)
+		} else {
+			t.Logf("Warning: Container %s has no resource requests", containerName)
+		}
+	}
+}
+
+func TestSecretsNotHardcoded(t *testing.T) {
+	strictMode := true
+	if v := os.Getenv("STRICT_SECRET_SCAN"); strings.EqualFold(v, "false") || v == "0" || strings.EqualFold(v, "no") {
+		strictMode = false
+	}
+
+	filesToCheck := []string{
+		"config/manager/manager.yaml",
+		"config/samples",
+		"helm-charts/redhat-trusted-profile-analyzer/values.yaml",
+	}
+
+	suspiciousPatterns := []string{
+		"password:",
+		"secret:",
+		"apiKey:",
+		"token:",
+		"key:",
+	}
+
+	var allMatches []secretMatch
+
+	for _, filePath := range filesToCheck {
+		info, err := os.Stat(filePath)
+		if err != nil {
+			continue
+		}
+
+		if info.IsDir() {
+			files, _ := os.ReadDir(filePath)
+			for _, file := range files {
+				if !file.IsDir() && (strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml")) {
+					allMatches = append(allMatches,
+						checkFileForSecrets(t, filepath.Join(filePath, file.Name()), suspiciousPatterns)...)
+				}
+			}
+		} else {
+			allMatches = append(allMatches, checkFileForSecrets(t, filePath, suspiciousPatterns)...)
+		}
+	}
+
+	var findings []secretMatch
+	for _, m := range allMatches {
+		if isAllowlisted(m) {
+			t.Logf("Allowlisted: %s:%d - %s", m.File, m.Line, m.Content)
+			continue
+		}
+		findings = append(findings, m)
+	}
+
+	for _, f := range findings {
+		if strictMode {
+			t.Errorf("Potential hardcoded secret in %s:%d - %s", f.File, f.Line, f.Content)
+		} else {
+			t.Logf("Potential hardcoded secret in %s:%d - %s", f.File, f.Line, f.Content)
+		}
+	}
+
+	if strictMode && len(findings) > 0 {
+		t.Logf("Set STRICT_SECRET_SCAN=false to treat secret findings as warnings instead of failures")
+	}
+}
+
+func checkFileForSecrets(t *testing.T, filePath string, patterns []string) []secretMatch {
+	t.Helper()
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+
+	var matches []secretMatch
+	lines := strings.Split(string(data), "\n")
+
+	for lineNum, line := range lines {
+		lineLower := strings.ToLower(line)
+
+		for _, pattern := range patterns {
+			if strings.Contains(lineLower, pattern) {
+				if strings.Contains(line, "value:") || strings.Contains(line, "=") {
+					if strings.Contains(line, "secretRef") ||
+						strings.Contains(line, "secretKeyRef") ||
+						strings.Contains(line, "change-me") ||
+						strings.Contains(line, "example") ||
+						strings.Contains(line, "CHANGEME") ||
+						strings.Contains(line, "<") {
+						continue
+					}
+
+					matches = append(matches, secretMatch{
+						File:    filePath,
+						Line:    lineNum + 1,
+						Content: strings.TrimSpace(line),
+					})
+				}
+			}
+		}
+	}
+
+	return matches
+}
+
+func isAllowlisted(m secretMatch) bool {
+	for _, entry := range secretAllowlist {
+		if strings.Contains(m.File, entry.File) && strings.Contains(m.Content, entry.Pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/testmain_test.go
+++ b/test/integration/testmain_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Integration tests reference paths relative to the repo root
+	// (config/, watches.yaml, helm-charts/), but Go sets CWD to the
+	// package directory (test/integration/) when running tests.
+	if err := os.Chdir("../.."); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to change to repo root: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/test/integration/watches_test.go
+++ b/test/integration/watches_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/operator-framework/helm-operator-plugins/pkg/watches"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const watchesFile = "watches.yaml"
+
+func TestWatchesFileStructure(t *testing.T) {
+	watchesPath := watchesFile
+
+	data, err := os.ReadFile(watchesPath)
+	require.NoError(t, err, "watches.yaml should be readable")
+
+	// Verify it's valid YAML
+	var watches []map[string]interface{}
+	err = yaml.Unmarshal(data, &watches)
+	require.NoError(t, err, "watches.yaml should be valid YAML")
+
+	assert.NotEmpty(t, watches, "watches should not be empty")
+}
+
+func TestWatchesGVKConfiguration(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err, "watches.yaml should load successfully")
+	require.Len(t, ws, 1, "should have exactly one watch configured")
+
+	w := ws[0]
+
+	// Verify GVK
+	assert.Equal(t, "rhtpa.io", w.Group, "group should be rhtpa.io")
+	assert.Equal(t, "v1", w.Version, "version should be v1")
+	assert.Equal(t, "TrustedProfileAnalyzer", w.Kind, "kind should be TrustedProfileAnalyzer")
+}
+
+func TestWatchesChartConfiguration(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+
+	w := ws[0]
+
+	// Verify chart path
+	assert.Equal(t, "helm-charts/redhat-trusted-profile-analyzer", w.ChartPath, "chart path should be correct")
+
+	// Verify chart path exists and is valid
+	chartYaml := filepath.Join(w.ChartPath, "Chart.yaml")
+	_, err = os.Stat(chartYaml)
+	assert.NoError(t, err, "Chart.yaml should exist at chart path")
+
+	valuesYaml := filepath.Join(w.ChartPath, "values.yaml")
+	_, err = os.Stat(valuesYaml)
+	assert.NoError(t, err, "values.yaml should exist at chart path")
+}
+
+func TestWatchesReconcilePeriod(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+
+	w := ws[0]
+
+	// Check if reconcile period is set
+	if w.ReconcilePeriod != nil {
+		t.Logf("Reconcile period: %v", w.ReconcilePeriod.Duration)
+		assert.Greater(t, w.ReconcilePeriod.Seconds(), float64(0), "reconcile period should be positive")
+	} else {
+		t.Log("Reconcile period not explicitly set, will use default")
+	}
+}
+
+func TestWatchesMaxConcurrentReconciles(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+
+	w := ws[0]
+
+	// Verify MaxConcurrentReconciles
+	require.NotNil(t, w.MaxConcurrentReconciles, "MaxConcurrentReconciles should be set")
+	assert.Greater(t, *w.MaxConcurrentReconciles, 0, "MaxConcurrentReconciles should be positive")
+	assert.Equal(t, 4, *w.MaxConcurrentReconciles, "MaxConcurrentReconciles should be 4")
+}
+
+func TestWatchesDependentResourcesConfiguration(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+
+	w := ws[0]
+
+	// Verify WatchDependentResources configuration
+	require.NotNil(t, w.WatchDependentResources, "WatchDependentResources should be explicitly set")
+	assert.False(t, *w.WatchDependentResources, "WatchDependentResources should be false for performance")
+}
+
+func TestWatchesSelectorConfiguration(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+
+	w := ws[0]
+
+	// Check selector configuration
+	if w.Selector != nil {
+		t.Logf("Selector configured: %+v", w.Selector)
+	} else {
+		t.Log("No selector configured - operator will watch all instances")
+	}
+}
+
+func TestWatchesOverrideValues(t *testing.T) {
+	ws, err := watches.Load(watchesFile)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+
+	w := ws[0]
+
+	// Check if override values are set
+	if len(w.OverrideValues) > 0 {
+		t.Logf("Override values configured: %+v", w.OverrideValues)
+
+		// Verify override values are valid
+		for key, value := range w.OverrideValues {
+			t.Logf("  %s: %v", key, value)
+			assert.NotEmpty(t, key, "override value key should not be empty")
+		}
+	} else {
+		t.Log("No override values configured")
+	}
+}
+
+func TestWatchesFileValidYAMLSyntax(t *testing.T) {
+	watchesPath := watchesFile
+
+	// Read file
+	_, err := os.ReadFile(watchesPath)
+	require.NoError(t, err, "watches.yaml should be readable")
+
+	// Try to unmarshal into watches structure
+	ws, err := watches.Load(watchesPath)
+	require.NoError(t, err, "watches.yaml should be valid watches configuration")
+	assert.NotEmpty(t, ws, "watches should not be empty")
+
+	// Verify required fields are present
+	for i, w := range ws {
+		assert.NotEmpty(t, w.Group, "watch %d should have group", i)
+		assert.NotEmpty(t, w.Version, "watch %d should have version", i)
+		assert.NotEmpty(t, w.Kind, "watch %d should have kind", i)
+		assert.NotEmpty(t, w.ChartPath, "watch %d should have chart path", i)
+	}
+}
+
+func TestWatchesFileNoTabTrailingSpaces(t *testing.T) {
+	watchesPath := watchesFile
+
+	data, err := os.ReadFile(watchesPath)
+	require.NoError(t, err, "watches.yaml should be readable")
+
+	// Check for common YAML issues
+	content := string(data)
+
+	// Should not have tab characters (YAML uses spaces)
+	assert.NotContains(t, content, "\t", "watches.yaml should not contain tab characters")
+}


### PR DESCRIPTION
Splitted commit of https://github.com/trustification/trusted-profile-analyzer-operator/pull/767 to permit the work of Sourcery-AI

See: https://redhat.atlassian.net/browse/TC-4177

Assisted-by: Claude: Opus 4.6

## Summary by Sourcery

Add integration test suite to validate operator configuration, Helm chart, CRDs, RBAC, and security-related settings.

Tests:
- Introduce security-focused integration tests for deployment security context, RBAC minimal privileges, service account, network policies, image pull policy, resource limits, and hardcoded secrets.
- Add RBAC integration tests to verify existence and correctness of roles, role bindings, leader election permissions, and service account configuration.
- Add watches.yaml integration tests to validate watched GVK, chart configuration, reconcile settings, and dependent resource options.
- Add Helm chart integration tests to verify Chart.yaml metadata, values.yaml defaults, schema file, templates structure, and helper files.
- Add CRD and sample CR integration tests to ensure CRD validity, versioning, and presence of valid sample resources.
- Add a TestMain helper to run integration tests from the repository root so relative config paths resolve correctly.

## Summary by Sourcery

Add integration tests to validate operator security posture, RBAC resources, watches configuration, Helm chart metadata and templates, CRDs and sample CRs, and ensure integration tests run from the repository root.

Tests:
- Add security-focused integration tests for operator deployment security context, RBAC minimal privileges, network policies, image pull policy, resource limits, and hardcoded secret scanning.
- Introduce RBAC integration tests to verify roles, job and ingress permissions, leader election permissions, service accounts, and role bindings.
- Add watches.yaml integration tests to validate GVK, chart path, reconcile settings, dependent resources configuration, selector, override values, and YAML formatting.
- Add Helm chart integration tests to check Chart.yaml fields, default values.yaml configuration, schema presence, templates layout, and key template files including NOTES and .helmignore.
- Add CRD and sample CustomResource integration tests to confirm CRD validity, version configuration, and presence of valid sample resources.
- Add a TestMain helper to run integration tests from the repository root to ensure relative configuration paths resolve correctly.