### PR TITLE
Porting helm fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/devel/README.md
+++ b/devel/README.md
@@ -55,8 +55,9 @@ update the operator sha and then run
   operator-sdk run bundle -n trustify quay.io/<your_username>/rhtpa-rhel10-operator-bundle:v2.0.0
 ```
 
-# Deploy an instance
+# Deploy an instance for development or demo
 From the UI or from cli with the values of trustify of namespace and services configured from helm-chart infrastructure
+Note: Storage filesystem is only for development/demo installation purposes, storage filesystem isn't designed for production or upgrades between different versions 
 ```console
 kubectl apply -f trusted-profile-analyzer-demo.yaml
 ```

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/common/010-PersistentVolumeClaim-storage.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/common/010-PersistentVolumeClaim-storage.yaml
@@ -1,13 +1,19 @@
-{{- if .Values.modules.server.enabled }}
 {{- $res := dict "root" . "name" "storage" -}}
 
 {{- if eq .Values.storage.type "filesystem" }}
+{{- $pvcName := (include "trustification.common.name" $res) }}
+{{- $existingPVC := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $pvcName) }}
+{{- if not $existingPVC }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "trustification.common.name" $res }}
   labels:
     {{- include "trustification.common.labels" $res | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-weight: "10"
+    helm.sh/resource-policy: keep
 
 spec:
   accessModes:

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
@@ -34,6 +34,7 @@ spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
 
       volumes:
+        {{- include "trustification.storage.volume" $mod | nindent 8 }}
         {{- include "trustification.application.extraVolumes" $mod | nindent 8 }}
 
       containers:
@@ -43,8 +44,9 @@ spec:
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}
-
+            {{- include "trustification.storage.envVars" $mod | nindent 12 }}
           volumeMounts:
+            {{- include "trustification.storage.volumeMount" $mod | nindent 12 }}
             {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}
 
           command:


### PR DESCRIPTION
See this https://github.com/guacsec/trustify-helm-charts/pull/89

## Summary by Sourcery

Port PVC handling and storage integration fixes into the common Helm templates for the trusted profile analyzer chart.

Enhancements:
- Move the storage PersistentVolumeClaim template from the server-specific path to a common location and add Helm hook annotations to preserve the PVC across installs and upgrades.
- Wire shared storage volumes, mounts, and environment variables into the migrate-database init Job to ensure it can access the configured storage backend.