### PR TITLE
Update helm chart225

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_deployment.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_deployment.tpl
@@ -6,7 +6,7 @@ Arguments (dict):
   * module - module object
 */}}
 {{- define "trustification.application.replicas" }}
-{{- .module.replicas | default .root.Values.replicas | default 1 }}
+{{- if hasKey .module "replicas" }}{{ .module.replicas }}{{- else if hasKey .root.Values "replicas" }}{{ .root.Values.replicas }}{{- else }}1{{- end }}
 {{- end }}
 
 {{/*

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_readOnly.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_readOnly.tpl
@@ -1,0 +1,20 @@
+{{/*
+Resolve the effective read-only flag: module-level overrides the global default.
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.application.readOnly.envVars" }}
+{{- if hasKey .module "readOnly" -}}
+{{- with .module.readOnly }}
+- name: TRUSTD_READ_ONLY
+  value: {{ . | quote }}
+{{- end }}
+{{- else -}}
+{{- with .root.Values.readOnly }}
+- name: TRUSTD_READ_ONLY
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
@@ -34,6 +34,7 @@ spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
 
       volumes:
+        {{- include "trustification.storage.volume" $mod | nindent 8 }}
         {{- include "trustification.application.extraVolumes" $mod | nindent 8 }}
 
       containers:
@@ -43,8 +44,10 @@ spec:
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}
+            {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 
           volumeMounts:
+            {{- include "trustification.storage.volumeMount" $mod | nindent 12 }}
             {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}
 
           command:

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
@@ -47,6 +47,7 @@ spec:
 
             {{- include "trustification.application.rust.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
@@ -49,6 +49,7 @@ spec:
             {{- include "trustification.application.rust.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.httpServer.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
             {{- include "trustification.oidc.swaggerUi" $mod | nindent 12 }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -64,6 +64,11 @@
     "oidc": {
       "$ref": "#/definitions/Oidc"
     },
+    "readOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Global default for read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\nCan be overridden per module via modules.server.readOnly / modules.importer.readOnly.\n"
+    },
     "replicas": {
       "type": "integer",
       "minimum": 0,
@@ -238,6 +243,10 @@
                 "maximumCacheSize": {
                   "description": "The maximum number of the bytes the analysis cache will hold before evicting entries.\n",
                   "$ref": "#/definitions/ByteSize"
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"
                 }
               }
             }
@@ -291,6 +300,10 @@
                 },
                 "storageClassName": {
                   "type": "string"
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"
                 }
               }
             }

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -67,6 +67,14 @@ properties:
   oidc:
     $ref: "#/definitions/Oidc"
 
+  readOnly:
+    type: boolean
+    default: false
+    description: |
+      Global default for read-only mode. When true, the server rejects all mutating API
+      requests with 503 and the importer suspends all import jobs.
+      Can be overridden per module via modules.server.readOnly / modules.importer.readOnly.
+
   replicas:
     type: integer
     minimum: 0
@@ -208,6 +216,11 @@ properties:
                 description: |
                   The maximum number of the bytes the analysis cache will hold before evicting entries.
                 $ref: "#/definitions/ByteSize"
+              readOnly:
+                type: boolean
+                description: |
+                  Enable read-only mode. When true, the server rejects all mutating API
+                  requests with 503 and the importer suspends all import jobs.
 
       importer:
         description: |
@@ -237,6 +250,11 @@ properties:
                   The max number of import jobs that may run concurrently
               storageClassName:
                 type: string
+              readOnly:
+                type: boolean
+                description: |
+                  Enable read-only mode. When true, the server rejects all mutating API
+                  requests with 503 and the importer suspends all import jobs.
 
       createDatabase:
         description: |

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -8,6 +8,8 @@ image:
 
 rust: {}
 
+readOnly: false
+
 ingress:
   enabled: true
 
@@ -42,7 +44,6 @@ collector: {}
 modules:
   server:
     enabled: true
-    replicas: 1
     ingress: {}
     image: {}
     infrastructure: {}
@@ -56,7 +57,6 @@ modules:
 
   importer:
     enabled: true
-    replicas: 1
     image: {}
     infrastructure: {}
     tracing: {}
@@ -67,6 +67,7 @@ modules:
         cpu: 1
         memory: 8Gi
     concurrency: 1
+    # readOnly: false
     workingDirectory:
       size: 32Gi
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable read-only mode and improve OIDC and deployment configuration for the redhat-trusted-profile-analyzer Helm chart.

New Features:
- Add a global and per-module read-only mode flag that controls server mutating APIs and importer jobs via the TRUSTD_READ_ONLY environment variable.
- Allow setting custom annotations on module deployments through a new annotations field in the module infrastructure schema.
- Expose a new keycloakPostInstall feature flag in the chart values.

Enhancements:
- Switch OIDC configuration from a single uiScope to uiScopes and wire it to the UI_SCOPES environment variable.
- Remove the unused UI_LOAD_USER OIDC toggle from values, schema, templates, and environment variables.
- Refine replica resolution logic to respect explicit module-level and global replica settings using presence checks instead of defaults.
- Ensure the migrate-database init Job mounts storage volumes and receives storage-related environment variables.