### PR TITLE
update rhtpa 3.0 rc image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.3 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trustification/trusted-profile-analyzer-operator
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/operator-framework/helm-operator-plugins v0.9.1

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:1f3f1280283122e6f29d8d4209a1f3c8ad37ea381ac4ec3ae44781ccced7b3e1 #@TODO update when el10 rhtpa image will be available
+  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:39205a1b998f668d2e2d37589462b33596196582780f568b20004772d594baa0 #@TODO update when el10 rhtpa image will be available
   pullPolicy: IfNotPresent
 
 rust: {}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:e0258ffff3e5b96730d1207a127599c7e6ba7b2a1914c80f6af1accb4d5d31ab #@TODO update when el10 rhtpa image will be available
+  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:1f3f1280283122e6f29d8d4209a1f3c8ad37ea381ac4ec3ae44781ccced7b3e1 #@TODO update when el10 rhtpa image will be available
   pullPolicy: IfNotPresent
 
 rust: {}


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Point the RHTPA Helm chart image reference to the latest RHEL 10-based registry.redhat.io image.