### PR TITLE
feat: auto-detect TLS security profile from OpenShift cluster

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,4 +80,12 @@ rules:
   - update
   - watch
 
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+
 # +kubebuilder:scaffold:rules

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_http.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_http.tpl
@@ -18,6 +18,8 @@ Arguments (dict):
   value: "/etc/tls/tls.crt"
 {{ end }}
 
+{{ include "trustification.tls.securityProfile.envVars" . }}
+
 {{- with .module.requestLimit }}
 - name: HTTP_SERVER_REQUEST_LIMIT
   value: {{ include "trustification.common.byteSizeValue" . }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_tls_profile.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_tls_profile.tpl
@@ -1,0 +1,76 @@
+{{/*
+Environment variables for the TLS security profile.
+
+Precedence:
+  1. User-specified via .Values.tls.securityProfile (string or object)
+  2. Auto-detected from OpenShift APIServer CR via lookup
+  3. Nothing (trustify server uses its compiled default: modern)
+
+Arguments (dict):
+  * root - .
+*/}}
+{{- define "trustification.tls.securityProfile.envVars" -}}
+
+{{- $profile := (.root.Values.tls).securityProfile -}}
+
+{{- if $profile -}}
+  {{/* User explicitly set tls.securityProfile */}}
+  {{- if kindIs "string" $profile }}
+- name: HTTP_SERVER_TLS_SECURITY_PROFILE
+  value: {{ $profile | quote }}
+  {{- else if kindIs "map" $profile }}
+- name: HTTP_SERVER_TLS_SECURITY_PROFILE
+  value: {{ $profile.type | quote }}
+    {{- if eq $profile.type "custom" }}
+      {{- with $profile.minTLSVersion }}
+- name: HTTP_SERVER_TLS_MIN_VERSION
+  value: {{ . | quote }}
+      {{- end }}
+      {{- with $profile.ciphers }}
+- name: HTTP_SERVER_TLS_CIPHERS
+  value: {{ join ":" . | quote }}
+      {{- end }}
+      {{- with $profile.ciphersuites }}
+- name: HTTP_SERVER_TLS_CIPHERSUITES
+  value: {{ join ":" . | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+{{- else if eq (include "trustification.openshift.detect" .root) "true" -}}
+  {{/* Auto-detect from OpenShift APIServer CR */}}
+  {{- $apiserver := (lookup "config.openshift.io/v1" "APIServer" "" "cluster") -}}
+  {{- $tlsProfile := dig "spec" "tlsSecurityProfile" dict $apiserver -}}
+  {{- with $tlsProfile -}}
+    {{- $type := .type | lower }}
+- name: HTTP_SERVER_TLS_SECURITY_PROFILE
+  value: {{ $type | quote }}
+    {{- if eq $type "custom" }}
+      {{- with .custom -}}
+        {{- with .minTLSVersion }}
+- name: HTTP_SERVER_TLS_MIN_VERSION
+  value: {{ include "trustification.tls.securityProfile.mapVersion" . | quote }}
+        {{- end }}
+        {{- with .ciphers }}
+- name: HTTP_SERVER_TLS_CIPHERS
+  value: {{ join ":" . | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}
+
+{{- end }}
+
+{{/*
+Map OpenShift TLS version names to trustify version strings.
+
+VersionTLS10 -> 1.0, VersionTLS11 -> 1.1, VersionTLS12 -> 1.2, VersionTLS13 -> 1.3
+
+Arguments: version string (e.g. "VersionTLS12")
+*/}}
+{{- define "trustification.tls.securityProfile.mapVersion" -}}
+{{- $map := dict "VersionTLS10" "1.0" "VersionTLS11" "1.1" "VersionTLS12" "1.2" "VersionTLS13" "1.3" -}}
+{{- get $map . | default . -}}
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -178,6 +178,51 @@ properties:
       additionalTrustAnchor:
         type: string
         description: The path of the certificate to add to the list of trust anchors
+      securityProfile:
+        description: |
+          TLS security profile aligned with OpenShift TLS Security Profiles.
+          On OpenShift, auto-detected from the cluster's APIServer CR if not set.
+          Can be a simple string (old, intermediate, modern) or an object with
+          type and custom settings.
+        oneOf:
+          - type: string
+            enum:
+              - old
+              - intermediate
+              - modern
+          - type: object
+            required:
+              - type
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                enum:
+                  - old
+                  - intermediate
+                  - modern
+                  - custom
+              minTLSVersion:
+                type: string
+                description: |
+                  Minimum TLS version (custom profile only).
+                enum:
+                  - "1.0"
+                  - "1.1"
+                  - "1.2"
+                  - "1.3"
+              ciphers:
+                type: array
+                items:
+                  type: string
+                description: |
+                  TLS 1.2 cipher list in OpenSSL format (custom profile only).
+              ciphersuites:
+                type: array
+                items:
+                  type: string
+                description: |
+                  TLS 1.3 ciphersuites in OpenSSL format (custom profile only).
 
   modules:
     type: object


### PR DESCRIPTION
Add support for configuring the trustify server's TLS security profile to align with OpenShift's centralized TLS Security Profiles (Old, Intermediate, Modern, Custom). This works with the new HTTP_SERVER_TLS_SECURITY_PROFILE env var added in trustify TC-3426.

The TLS security profile is resolved with three-tier precedence:

1. User-specified: set tls.securityProfile in the CR spec (as a simple string like "intermediate" or as an object with custom cipher config)
2. Auto-detected: on OpenShift, the operator reads the APIServer CR (config.openshift.io/v1, named "cluster") using Helm's lookup function and extracts spec.tlsSecurityProfile
3. Compiled default: if neither is available (vanilla Kubernetes, or helm template dry-run where lookup returns empty), no env var is set and the trustify server uses its compiled default (modern/TLS 1.3)

For custom profiles, the operator also sets HTTP_SERVER_TLS_MIN_VERSION, HTTP_SERVER_TLS_CIPHERS, and HTTP_SERVER_TLS_CIPHERSUITES. OpenShift's VersionTLS* names (e.g. VersionTLS12) are mapped to trustify's format (e.g. 1.2), and cipher lists are colon-joined.

Changes:
- New _tls_profile.tpl helper with profile resolution and version mapping
- _http.tpl calls the new helper for all HTTP server deployments
- values.schema.yaml adds tls.securityProfile (string or object with type, minTLSVersion, ciphers, ciphersuites)
- RBAC ClusterRole gains get/list on config.openshift.io/apiservers

Implements TC-3426

## Summary by Sourcery

Add support for configuring the TLS security profile for HTTP servers, including auto-detection from OpenShift APIServer configuration, while preserving existing defaults.

New Features:
- Introduce a tls.securityProfile Helm value allowing explicit selection or customisation of the TLS security profile, including min TLS version and cipher configuration.
- Add a Helm helper that configures HTTP server TLS-related environment variables based on user settings or OpenShift APIServer TLS security profile.

Enhancements:
- Wire the new TLS security profile helper into existing HTTP server templates so all HTTP deployments respect the resolved profile.

Chores:
- Extend operator RBAC to allow reading OpenShift APIServer resources needed for TLS profile auto-detection.