### PR TITLE
Update operator manually

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -262,7 +262,7 @@ spec:
                       - --metrics-bind-address=:8443
                       - --leader-elect
                       - --health-probe-bind-address=:8081
-                    image: registry.redhat.io/rhtpa/rhtpa-rhel10-operator@sha256:da1814230bf30f08bf6be2f50a1b79796fab62a1cfd802b6cc00f20d3bb524c7
+                    image: registry.redhat.io/rhtpa/rhtpa-rhel10-operator@sha256:5fbc729db39b4e57845c43f79b6ca08094a8eee328cd3f51dcf9eda22325deb6
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -371,6 +371,6 @@ spec:
     name: Red Hat
     url: https://github.com/trustification/trusted-profile-analyzer-operator
   relatedImages:
-    - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:665ce9333e5a48a2894dfb8c04dbe82143c8bde751a98d39538883c6d15059ae
+    - image: registry.redhat.io/rhtpa/rhtpa-rhel9-operator@sha256:5fbc729db39b4e57845c43f79b6ca08094a8eee328cd3f51dcf9eda22325deb6
       name: manager
   version: 2.0.0


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Refresh operator container image digests in the ClusterServiceVersion to point to updated rhtpa-rhel9 and rhtpa-rhel10 images.