### PR TITLE
Add storage env vars to migrate-db job

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
@@ -34,6 +34,7 @@ spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
 
       volumes:
+        {{- include "trustification.storage.volume" $mod | nindent 8 }}
         {{- include "trustification.application.extraVolumes" $mod | nindent 8 }}
 
       containers:
@@ -43,8 +44,10 @@ spec:
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}
+            {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 
           volumeMounts:
+            {{- include "trustification.storage.volumeMount" $mod | nindent 12 }}
             {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}
 
           command:


### PR DESCRIPTION
The migrate-db job only had database env vars injected, but the trustd binary initializes storage via LazyLock on first access, parsing config from environment variables. Without TRUSTD_STORAGE_STRATEGY and S3 credentials, it defaults to filesystem storage and crashes with "Permission denied" when trying to create .trustify/storage directory.

Add trustification.storage.envVars, volumeMount, and volume to the migrate-db job template, matching what the server and importer deployments already have.

Assisted-by: Claude Code

## Summary by Sourcery

Include storage configuration in the migrate-db initialization job to align it with other trustd workloads.

New Features:
- Inject storage-related environment variables into the migrate-db job so trustd can initialize its storage backend correctly.

Enhancements:
- Mount the storage volume and corresponding volumeMounts in the migrate-db job template to match server and importer deployments.