### PR TITLE
[2.0.0] Correct nindent for container resources in Job templates

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/create-database/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/create-database/020-Job.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
         - name: job
           {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
-          {{- include "trustification.application.container" $mod | nindent 6 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
 
           env:
             # connect using the `createDatabase` settings

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/create-importers/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/create-importers/020-Job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: job
           {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
-          {{- include "trustification.application.container" $mod | nindent 6 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
 
           env:
             {{- include "trustification.psql.envVars" ( dict "root" . "database" ( merge ( deepCopy (.Values.modules.createImporters.database | default dict ) ) (deepCopy .Values.database) ) ) | nindent 12 }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: job
           {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
-          {{- include "trustification.application.container" $mod | nindent 6 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix mis-indented application container block in init Job templates so container resources are correctly associated with the job container.