### PR TITLE
fix: remove TPA 3.0 storage includes from migrate-db Job

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/init/migrate-database/020-Job.yaml
@@ -34,7 +34,6 @@ spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
 
       volumes:
-        {{- include "trustification.storage.volume" $mod | nindent 8 }}
         {{- include "trustification.application.extraVolumes" $mod | nindent 8 }}
 
       containers:
@@ -44,10 +43,8 @@ spec:
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}
-            {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 
           volumeMounts:
-            {{- include "trustification.storage.volumeMount" $mod | nindent 12 }}
             {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}
 
           command:


### PR DESCRIPTION
## Summary

- Remove three storage-related Helm template includes (`trustification.storage.volume`, `.envVars`, `.volumeMount`) from the `migrate-db` Job that were incorrectly added in commit `7cae5d9`
- These includes create a PVC dependency that causes `persistentvolumeclaim "storage" not found` when deploying TPA operator v1.1.5
- Storage is only needed in TPA 3.0 (where `trustd db migrate` integrates data migrations via `MigrationWithData`), not in TPA 2.2.5 (schema-only migrations)

Implements [TC-4983](https://redhat.atlassian.net/browse/TC-4983)

## Verification

Cross-verified against 6 sources:
- Upstream trustify `release/0.4.z` (TPA 2.2.5): schema-only migrations, no storage needed
- Upstream trustify `release/0.5.z` (TPA 3.0): data migrations integrated, storage needed
- Downstream helm chart `release/2.2.z`: no storage includes (correct)
- Downstream helm chart `release/3.0.z`: has storage includes (correct)
- Operator `main`: no storage includes (correct)
- Operator `release/1.1.z` (before this fix): incorrectly has storage includes

## Test plan

- [ ] `helm template` of migrate-db Job renders without `storage` volume, volumeMount, or `TRUSTD_STORAGE_*` env vars
- [ ] Full chart renders without errors
- [ ] Other init Jobs (create-database, create-importers) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Eliminate an incorrect storage PVC dependency from the migrate-db Job that caused deployment failures when the storage claim is not present.