### PR TITLE
Storage not deployed in the released operator

### DIFF
--- a/Dockerfile.rhtpa-operator.rh.dockerignore
+++ b/Dockerfile.rhtpa-operator.rh.dockerignore
@@ -1,0 +1,6 @@
+# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Ignore build and test binaries.
+bin/
+testbin/
+# Exclude storage templates from release image
+helm-charts/redhat-trusted-profile-analyzer/templates/common/


### PR DESCRIPTION
Assisted-by: Claude: Opus 4.6

Remove FileStorage creation from released image.

## Summary by Sourcery

Introduce a dockerignore configuration for the released operator image to align the build context with expected storage deployment behavior.

Bug Fixes:
- Ensure storage-related artifacts are correctly excluded from the released operator image build context via a dedicated .dockerignore file.

Build:
- Add Dockerfile.rhtpa-operator.rh.dockerignore to control the build context for the released operator image.