### PR TITLE
Readonly flag

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_readOnly.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_readOnly.tpl
@@ -1,0 +1,20 @@
+{{/*
+Resolve the effective read-only flag: module-level overrides the global default.
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.application.readOnly.envVars" }}
+{{- if hasKey .module "readOnly" -}}
+{{- with .module.readOnly }}
+- name: TRUSTD_READ_ONLY
+  value: {{ . | quote }}
+{{- end }}
+{{- else -}}
+{{- with .root.Values.readOnly }}
+- name: TRUSTD_READ_ONLY
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
@@ -47,6 +47,7 @@ spec:
 
             {{- include "trustification.application.rust.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
@@ -49,6 +49,7 @@ spec:
             {{- include "trustification.application.rust.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.httpServer.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
             {{- include "trustification.oidc.swaggerUi" $mod | nindent 12 }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -64,6 +64,11 @@
     "oidc": {
       "$ref": "#/definitions/Oidc"
     },
+    "readOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Global default for read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\nCan be overridden per module via modules.server.readOnly / modules.importer.readOnly.\n"
+    },
     "replicas": {
       "type": "integer",
       "minimum": 0,
@@ -238,6 +243,10 @@
                 "maximumCacheSize": {
                   "description": "The maximum number of the bytes the analysis cache will hold before evicting entries.\n",
                   "$ref": "#/definitions/ByteSize"
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"
                 }
               }
             }
@@ -291,6 +300,10 @@
                 },
                 "storageClassName": {
                   "type": "string"
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"
                 }
               }
             }

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -67,6 +67,14 @@ properties:
   oidc:
     $ref: "#/definitions/Oidc"
 
+  readOnly:
+    type: boolean
+    default: false
+    description: |
+      Global default for read-only mode. When true, the server rejects all mutating API
+      requests with 503 and the importer suspends all import jobs.
+      Can be overridden per module via modules.server.readOnly / modules.importer.readOnly.
+
   replicas:
     type: integer
     minimum: 0
@@ -208,7 +216,11 @@ properties:
                 description: |
                   The maximum number of the bytes the analysis cache will hold before evicting entries.
                 $ref: "#/definitions/ByteSize"
-
+              readOnly:
+                type: boolean
+                description: |
+                  Enable read-only mode. When true, the server rejects all mutating API
+                  requests with 503 and the importer suspends all import jobs.
       importer:
         description: |
           The main server process.
@@ -237,6 +249,11 @@ properties:
                   The max number of import jobs that may run concurrently
               storageClassName:
                 type: string
+              readOnly:
+                type: boolean
+                description: |
+                  Enable read-only mode. When true, the server rejects all mutating API
+                  requests with 503 and the importer suspends all import jobs.
 
       createDatabase:
         description: |

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -8,6 +8,8 @@ image:
 
 rust: {}
 
+readOnly: false
+
 ingress:
   enabled: true
 
@@ -67,6 +69,7 @@ modules:
         cpu: 1
         memory: 8Gi
     concurrency: 1
+    # readOnly: false
     workingDirectory:
       size: 32Gi
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable read-only mode for the application with global and per-module controls, wiring it through Helm values and deployment templates.

New Features:
- Add a global readOnly flag and per-module readOnly overrides to the Helm chart values and schema for the server and importer.
- Expose the effective read-only configuration to server and importer pods via TRUSTD_READ_ONLY environment variables derived from Helm values.

Enhancements:
- Refine Helm helper templates to centralize resolution of effective read-only settings between global and module-level configuration.