### PR TITLE
3.0.0-0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.42.2
+OPERATOR_SDK_VERSION ?= v1.42.3
 OPM_VERSION = v1.55.0
 
 # Image URL to use all building/pushing image targets

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_proxy.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_proxy.tpl
@@ -1,0 +1,28 @@
+{{/*
+Proxy env-vars for containers that need HTTP proxy support.
+
+Arguments (dict):
+  * root - .
+*/}}
+{{- define "trustification.application.proxy.envVars" -}}
+{{- with .root.Values.proxy }}
+{{- with .httpProxy }}
+- name: HTTP_PROXY
+  value: {{ . | quote }}
+- name: http_proxy
+  value: {{ . | quote }}
+{{- end }}
+{{- with .httpsProxy }}
+- name: HTTPS_PROXY
+  value: {{ . | quote }}
+- name: https_proxy
+  value: {{ . | quote }}
+{{- end }}
+{{- with .noProxy }}
+- name: NO_PROXY
+  value: {{ . | quote }}
+- name: no_proxy
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
@@ -50,6 +50,7 @@ spec:
             {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.proxy.envVars" $mod | nindent 12 }}
 
           ports:
             {{- include "trustification.application.infrastructure.podPorts" $mod | nindent 12 }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -179,6 +179,9 @@
         }
       }
     },
+    "proxy": {
+      "$ref": "#/definitions/ProxyConfig"
+    },
     "rust": {
       "$ref": "#/definitions/RustApplicationConfig"
     },
@@ -453,6 +456,25 @@
     }
   ],
   "definitions": {
+    "ProxyConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "HTTP proxy configuration. When set, the corresponding environment variables\n(HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are injected into the importer container.\n",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "description": "HTTP proxy URL (sets HTTP_PROXY)"
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "HTTPS proxy URL (sets HTTPS_PROXY)"
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "Comma-separated list of hosts to bypass the proxy (sets NO_PROXY)"
+        }
+      }
+    },
     "Scalable": {
       "description": "Configuration options for a scalable deployment.\n",
       "allOf": [

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -176,6 +176,8 @@ properties:
         pattern: ^(http|https)://
         description: |
           OpenTelemetry collector endpoint for tracing and metrics.
+  proxy:
+    $ref: "#/definitions/ProxyConfig"
 
   rust:
     $ref: "#/definitions/RustApplicationConfig"
@@ -351,6 +353,23 @@ allOf:
 # all the definitions
 
 definitions:
+
+  ProxyConfig:
+    type: object
+    additionalProperties: false
+    description: |
+      HTTP proxy configuration. When set, the corresponding environment variables
+      (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are injected into the importer container.
+    properties:
+      httpProxy:
+        type: string
+        description: HTTP proxy URL (sets HTTP_PROXY)
+      httpsProxy:
+        type: string
+        description: HTTPS proxy URL (sets HTTPS_PROXY)
+      noProxy:
+        type: string
+        description: Comma-separated list of hosts to bypass the proxy (sets NO_PROXY)
 
   Scalable:
     description: |

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,10 +3,12 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:1feddb1d2b1b1f70078deea5f2fe61108b640368a4c8c8097bcca749ed4a93be
+  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:49452c81d0c1e6f067fac2b7abcda38bf09273f101ffc4bd6cb62411814426f1
   pullPolicy: IfNotPresent
 
 rust: {}
+
+proxy: {}
 
 readOnly: false
 


### PR DESCRIPTION
3.0.0-0.5.0 image 
Http Proxy configuration

## Summary by Sourcery

Update tooling and image references for the trusted profile analyzer release.

Build:
- Bump Operator SDK version used by the Makefile from v1.42.2 to v1.42.3.

Deployment:
- Update Helm chart image digest for the redhat-trusted-profile-analyzer component.