### PR TITLE
Http Proxy importer

### DIFF
--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_proxy.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_proxy.tpl
@@ -1,0 +1,28 @@
+{{/*
+Proxy env-vars for containers that need HTTP proxy support.
+
+Arguments (dict):
+  * root - .
+*/}}
+{{- define "trustification.application.proxy.envVars" -}}
+{{- with .root.Values.proxy }}
+{{- with .httpProxy }}
+- name: HTTP_PROXY
+  value: {{ . | quote }}
+- name: http_proxy
+  value: {{ . | quote }}
+{{- end }}
+{{- with .httpsProxy }}
+- name: HTTPS_PROXY
+  value: {{ . | quote }}
+- name: https_proxy
+  value: {{ . | quote }}
+{{- end }}
+{{- with .noProxy }}
+- name: NO_PROXY
+  value: {{ . | quote }}
+- name: no_proxy
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/importer/030-Deployment.yaml
@@ -50,6 +50,7 @@ spec:
             {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.proxy.envVars" $mod | nindent 12 }}
 
           ports:
             {{- include "trustification.application.infrastructure.podPorts" $mod | nindent 12 }}

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -179,6 +179,9 @@
         }
       }
     },
+    "proxy": {
+      "$ref": "#/definitions/ProxyConfig"
+    },
     "rust": {
       "$ref": "#/definitions/RustApplicationConfig"
     },
@@ -449,6 +452,25 @@
     }
   ],
   "definitions": {
+    "ProxyConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "HTTP proxy configuration. When set, the corresponding environment variables\n(HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are injected into the importer container.\n",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "description": "HTTP proxy URL (sets HTTP_PROXY)"
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "HTTPS proxy URL (sets HTTPS_PROXY)"
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "Comma-separated list of hosts to bypass the proxy (sets NO_PROXY)"
+        }
+      }
+    },
     "Scalable": {
       "description": "Configuration options for a scalable deployment.\n",
       "allOf": [

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -177,6 +177,9 @@ properties:
         description: |
           OpenTelemetry collector endpoint for tracing and metrics.
 
+  proxy:
+    $ref: "#/definitions/ProxyConfig"
+
   rust:
     $ref: "#/definitions/RustApplicationConfig"
 
@@ -345,6 +348,23 @@ allOf:
 # all the definitions
 
 definitions:
+
+  ProxyConfig:
+    type: object
+    additionalProperties: false
+    description: |
+      HTTP proxy configuration. When set, the corresponding environment variables
+      (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are injected into the importer container.
+    properties:
+      httpProxy:
+        type: string
+        description: HTTP proxy URL (sets HTTP_PROXY)
+      httpsProxy:
+        type: string
+        description: HTTPS proxy URL (sets HTTPS_PROXY)
+      noProxy:
+        type: string
+        description: Comma-separated list of hosts to bypass the proxy (sets NO_PROXY)
 
   Scalable:
     description: |

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -6,6 +6,8 @@ image:
   fullName: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4d024a6b748997b2cc757f53a7f0c3fe7f80789b74f7325837d93ecd0273bb58
   pullPolicy: IfNotPresent
 
+proxy: {}
+
 rust: {}
 
 readOnly: false


### PR DESCRIPTION
## Summary by Sourcery

Add configurable HTTP proxy support to the importer deployment via Helm values and helper templates.

New Features:
- Introduce a ProxyConfig section in Helm values to configure HTTP, HTTPS, and NO proxy settings for the importer.
- Inject corresponding HTTP_PROXY/HTTPS_PROXY/NO_PROXY (and lowercase variants) environment variables into the importer container when proxy settings are provided.

Tests:
- Add Helm unit tests to verify proxy environment variables are injected or omitted based on the proxy configuration in values.