### PR TITLE
feat: add configurable values for exploit intelligence integration

### DIFF
--- a/config/samples/v1_trustedprofileanalyzer.yaml
+++ b/config/samples/v1_trustedprofileanalyzer.yaml
@@ -7,6 +7,8 @@ spec:
   appDomain: change-me
   collector: {}
   database: {}
+  exploitIntelligence:
+    enabled: false
   infrastructure:
     port: 9010
   ingress: {}
@@ -65,5 +67,3 @@ spec:
   tls: {}
   tracing:
     enabled: false
-  
-  

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_auth.tpl
@@ -99,6 +99,7 @@ authentication:
       additionalPermissions:
         - "ai"
         - "read.advisory"
+        - "read.exploitIntelligence"
         - "read.importer"
         - "read.metadata"
         - "read.sbom"
@@ -110,6 +111,7 @@ authentication:
       groupMappings:
         manager:
           - "create.advisory"
+          - "create.exploitIntelligence"
           - "create.importer"
           - "create.metadata"
           - "create.sbom"
@@ -180,8 +182,8 @@ authentication:
     - clientId: {{ include "trustification.oidc.clientId" (dict "root" .root "clientId" "frontend" ) }}
       issuerUrl: {{ include "trustification.oidc.issuerUrlForClient" (dict "root" .root "clientId" "frontend" ) }}
       scopeMappings: &keycloakScopeMappings
-        "create:document": [ "create.advisory", "create.importer", "create.metadata", "create.sbom", "create.sbomGroup", "create.weakness", "upload.dataset" ]
-        "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.sbomGroup", "read.weakness", "read.systemInformation" ]
+        "create:document": [ "create.advisory", "create.exploitIntelligence", "create.importer", "create.metadata", "create.sbom", "create.sbomGroup", "create.weakness", "upload.dataset" ]
+        "read:document": [ "ai", "read.advisory", "read.exploitIntelligence", "read.importer", "read.metadata", "read.sbom", "read.sbomGroup", "read.weakness", "read.systemInformation" ]
         "update:document": [ "update.advisory", "update.importer", "update.metadata", "update.sbom", "update.sbomGroup", "update.weakness" ]
         "delete:document": [ "delete.advisory", "delete.importer", "delete.metadata", "delete.sbom", "delete.sbomGroup", "delete.vulnerability", "delete.weakness" ]
       {{- with .root.Values.tls.additionalTrustAnchor }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_exploit_intelligence.tpl
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/helpers/_exploit_intelligence.tpl
@@ -1,0 +1,67 @@
+{{/*
+Exploit Intelligence configuration env-vars.
+
+Arguments (dict):
+  * root - .
+*/}}
+{{- define "trustification.exploit-intelligence.envVars" }}
+
+{{- if .root.Values.exploitIntelligence.enabled }}
+
+{{- $ei := .root.Values.exploitIntelligence }}
+
+- name: EXPLOIT_INTELLIGENCE_URL
+  {{- include "trustification.common.requiredEnvVarValue" (dict "value" $ei.url "msg" "exploitIntelligence.url is required when exploitIntelligence.enabled is true") | nindent 2 }}
+
+{{- with $ei.uiUrl }}
+- name: EXPLOIT_INTELLIGENCE_UI_URL
+  {{- include "trustification.common.envVarValue" . | nindent 2 }}
+{{- end }}
+
+{{- with $ei.maxRetries }}
+- name: EXPLOIT_INTELLIGENCE_MAX_RETRIES
+  value: {{ . | quote }}
+{{- end }}
+
+{{- with $ei.workerPollInterval }}
+- name: EXPLOIT_INTELLIGENCE_WORKER_POLL_INTERVAL
+  value: {{ . | quote }}
+{{- end }}
+
+{{- with $ei.concurrency }}
+- name: EXPLOIT_INTELLIGENCE_CONCURRENCY
+  value: {{ . | quote }}
+{{- end }}
+
+{{- with $ei.oidc }}
+
+{{- with .clientId }}
+- name: EXPLOIT_INTELLIGENCE_OIDC_CLIENT_ID
+  {{- include "trustification.common.envVarValue" . | nindent 2 }}
+{{- end }}
+
+{{- with .clientSecret }}
+- name: EXPLOIT_INTELLIGENCE_OIDC_CLIENT_SECRET
+  {{- include "trustification.common.envVarValue" . | nindent 2 }}
+{{- end }}
+
+{{- with .issuerUrl }}
+- name: EXPLOIT_INTELLIGENCE_OIDC_ISSUER_URL
+  {{- include "trustification.common.envVarValue" . | nindent 2 }}
+{{- end }}
+
+{{- with .refreshBefore }}
+- name: EXPLOIT_INTELLIGENCE_OIDC_REFRESH_BEFORE
+  value: {{ . | quote }}
+{{- end }}
+
+{{- if .tlsInsecure }}
+- name: EXPLOIT_INTELLIGENCE_OIDC_TLS_INSECURE
+  value: "true"
+{{- end }}
+
+{{- end }}{{/* with $ei.oidc */}}
+
+{{- end }}{{/* if enabled */}}
+
+{{- end }}

--- a/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/templates/services/server/030-Deployment.yaml
@@ -53,6 +53,7 @@ spec:
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
             {{- include "trustification.oidc.swaggerUi" $mod | nindent 12 }}
+            {{- include "trustification.exploit-intelligence.envVars" $mod | nindent 12 }}
 
             {{- with (include "trustification.application.cache.ttl" . | trim) }}
             - name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.json
@@ -64,6 +64,9 @@
     "oidc": {
       "$ref": "#/definitions/Oidc"
     },
+    "exploitIntelligence": {
+      "$ref": "#/definitions/ExploitIntelligence"
+    },
     "readOnly": {
       "type": "boolean",
       "default": false,
@@ -253,7 +256,7 @@
                 },
                 "cacheTTL": {
                   "type": "string",
-                  "description": "the time a cache is allowed to live (in s) before forcing a reload.\n"
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\nthe time a cache is allowed to live (in s) before forcing a reload.\n"
                 }
               }
             }
@@ -449,6 +452,31 @@
           "collector": {
             "required": [
               "endpoint"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "exploitIntelligence": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "exploitIntelligence": {
+            "required": [
+              "url"
             ]
           }
         }
@@ -1156,6 +1184,85 @@
           "type": "number",
           "minimum": 1,
           "description": "The number of HTTP workers of the Actix application.\n\nAlso see: <https://actix.rs/docs/server/#multi-threading>\n"
+        }
+      }
+    },
+    "ExploitIntelligence": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configuration for the Exploit Intelligence integration. When enabled, trustify can submit\nSBOMs and CVEs to an external EI client service (agent-morpheus-client) for automated\nvulnerability analysis and VEX document generation.\n",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the Exploit Intelligence integration.\n",
+          "default": false
+        },
+        "url": {
+          "$ref": "#/definitions/ValueOrRef",
+          "description": "Base URL of the EI client service (agent-morpheus-client).\n"
+        },
+        "uiUrl": {
+          "$ref": "#/definitions/ValueOrRef",
+          "description": "Base URL of the EI web UI for deep-linking to reports. Fallsback to base URL of the EI client service if unset.\n"
+        },
+        "maxRetries": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum number of retry attempts before a job is marked as failed.\n"
+        },
+        "workerPollInterval": {
+          "type": "string",
+          "description": "How often the background worker checks for new EI jobs (humantime, e.g. \"5s\").\n"
+        },
+        "concurrency": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of concurrent worker loops processing EI jobs.\n"
+        },
+        "oidc": {
+          "$ref": "#/definitions/ExploitIntelligenceOidc"
+        }
+      }
+    },
+    "ExploitIntelligenceOidc": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OIDC credentials for authenticating with the EI service using client credentials flow.\nAll three of clientId, clientSecret, and issuerUrl must be set together.\n",
+      "dependencies": {
+        "clientId": [
+          "clientSecret",
+          "issuerUrl"
+        ],
+        "clientSecret": [
+          "clientId",
+          "issuerUrl"
+        ],
+        "issuerUrl": [
+          "clientId",
+          "clientSecret"
+        ]
+      },
+      "properties": {
+        "clientId": {
+          "$ref": "#/definitions/ValueOrRef",
+          "description": "OIDC client ID for EI service authentication.\n"
+        },
+        "clientSecret": {
+          "$ref": "#/definitions/ValueOrRef",
+          "description": "OIDC client secret for EI service authentication.\n"
+        },
+        "issuerUrl": {
+          "$ref": "#/definitions/ValueOrRef",
+          "description": "OIDC issuer URL for EI service authentication (client credentials flow with discovery).\n"
+        },
+        "refreshBefore": {
+          "type": "string",
+          "description": "Duration an access token must still be valid before requesting a new one (humantime).\n"
+        },
+        "tlsInsecure": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow insecure TLS connections with the EI OIDC issuer.\n"
         }
       }
     }

--- a/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.schema.yaml
@@ -67,6 +67,9 @@ properties:
   oidc:
     $ref: "#/definitions/Oidc"
 
+  exploitIntelligence:
+    $ref: "#/definitions/ExploitIntelligence"
+
   readOnly:
     type: boolean
     default: false
@@ -349,6 +352,19 @@ allOf:
         collector:
           required:
             - endpoint
+  - if:
+      properties:
+        exploitIntelligence:
+          properties:
+            enabled:
+              const: true
+          required:
+            - enabled
+    then:
+      properties:
+        exploitIntelligence:
+          required:
+            - url
 
 # all the definitions
 
@@ -910,3 +926,75 @@ definitions:
           The number of HTTP workers of the Actix application.
 
           Also see: <https://actix.rs/docs/server/#multi-threading>
+
+  ExploitIntelligence:
+    type: object
+    additionalProperties: false
+    description: |
+      Configuration for the Exploit Intelligence integration. When enabled, trustify can submit
+      SBOMs and CVEs to an external EI client service (agent-morpheus-client) for automated
+      vulnerability analysis and VEX document generation.
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Enable the Exploit Intelligence integration.
+        default: false
+      url:
+        $ref: "#/definitions/ValueOrRef"
+        description: |
+          Base URL of the EI client service (agent-morpheus-client).
+      uiUrl:
+        $ref: "#/definitions/ValueOrRef"
+        description: |
+          Base URL of the EI web UI for deep-linking to reports. Fallsback to base URL of the EI client service if unset.
+      maxRetries:
+        type: integer
+        minimum: 0
+        description: |
+          Maximum number of retry attempts before a job is marked as failed.
+      workerPollInterval:
+        type: string
+        description: |
+          How often the background worker checks for new EI jobs (humantime, e.g. "5s").
+      concurrency:
+        type: integer
+        minimum: 1
+        description: |
+          Number of concurrent worker loops processing EI jobs.
+      oidc:
+        $ref: "#/definitions/ExploitIntelligenceOidc"
+
+  ExploitIntelligenceOidc:
+    type: object
+    additionalProperties: false
+    description: |
+      OIDC credentials for authenticating with the EI service using client credentials flow.
+      All three of clientId, clientSecret, and issuerUrl must be set together.
+    dependencies:
+      clientId: [ "clientSecret", "issuerUrl" ]
+      clientSecret: [ "clientId", "issuerUrl" ]
+      issuerUrl: [ "clientId", "clientSecret" ]
+    properties:
+      clientId:
+        $ref: "#/definitions/ValueOrRef"
+        description: |
+          OIDC client ID for EI service authentication.
+      clientSecret:
+        $ref: "#/definitions/ValueOrRef"
+        description: |
+          OIDC client secret for EI service authentication.
+      issuerUrl:
+        $ref: "#/definitions/ValueOrRef"
+        description: |
+          OIDC issuer URL for EI service authentication (client credentials flow with discovery).
+      refreshBefore:
+        type: string
+        description: |
+          Duration an access token must still be valid before requesting a new one (humantime).
+      tlsInsecure:
+        type: boolean
+        default: false
+        description: |
+          Allow insecure TLS connections with the EI OIDC issuer.
+

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -43,6 +43,9 @@ tracing:
 
 collector: {}
 
+exploitIntelligence:
+  enabled: false
+
 modules:
   server:
     enabled: true


### PR DESCRIPTION
As part of TPA changes in https://github.com/guacsec/trustify/pull/2464

## Summary by Sourcery

Add configurable Exploit Intelligence integration to the Trusted Profile Analyzer Helm chart and deployment.

New Features:
- Introduce exploitIntelligence configuration section with URL, polling, retry, and OIDC options for integrating with an external Exploit Intelligence service.
- Expose Exploit Intelligence-related environment variables to the server deployment when the integration is enabled.
- Extend sample TrustedProfileAnalyzer CR and default values to include exploitIntelligence.enabled.
- Grant RBAC and scope mappings for creating and reading Exploit Intelligence resources in the authentication helper templates.

Enhancements:
- Enforce schema validation that requires an Exploit Intelligence URL when the integration is enabled.