### PR TITLE
Fix tekton

### DIFF
--- a/.tekton/operator-3-y-z-push.yaml
+++ b/.tekton/operator-3-y-z-push.yaml
@@ -32,6 +32,10 @@ spec:
     value: Dockerfile.rhtpa-operator.rh
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/operator-3-y-z-push.yaml
+++ b/.tekton/operator-3-y-z-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: build-source-image
     value: "true"
   - name: hermetic
-    value: "false"
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/operator-bundle-3-y-z-push.yaml
+++ b/.tekton/operator-bundle-3-y-z-push.yaml
@@ -32,6 +32,10 @@ spec:
     value: bundle.Dockerfile
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
## Summary by Sourcery

Update Tekton operator push pipelines to configure source image builds and hermetic mode for operator and bundle images.

Build:
- Configure build-source-image and hermetic parameters in the operator container image push pipeline.
- Configure build-source-image and hermetic parameters in the operator bundle image push pipeline.