### PR TITLE
Fix tekton

### DIFF
--- a/.tekton/operator-3-y-z-pull-request.yaml
+++ b/.tekton/operator-3-y-z-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: Dockerfile.rhtpa-operator.rh
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/operator-3-y-z-push.yaml
+++ b/.tekton/operator-3-y-z-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: build-source-image
     value: "true"
   - name: hermetic
-    value: "true"
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/operator-bundle-3-y-z-pull-request.yaml
+++ b/.tekton/operator-bundle-3-y-z-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: bundle.Dockerfile
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
## Summary by Sourcery

Update Tekton operator pipelines to configure source image building and disable hermetic mode.

Build:
- Add build-source-image and hermetic parameters to operator pull request Tekton pipelines.
- Set hermetic mode to false in the operator push Tekton pipeline configuration.