### PR TITLE
Prepare 3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,11 @@ LABEL description="Red Hat Trusted Profile Analyzer Operator"
 LABEL io.k8s.description="Red Hat Trusted Profile Analyzer Operator"
 LABEL io.k8s.display-name="RHTPA operator for Red Hat Trusted Profile Analyzer"
 LABEL io.openshift.tags="RHTPA, rhtpa-operator, Red Hat Trusted Profile Analyzer"
-LABEL name="rhtpa/rhtpa-rhel9-operator"
+LABEL name="rhtpa/rhtpa-rhel10-operator"
 LABEL org.opencontainers.image.source="https://github.com/trustification/trusted-profile-analyzer-operator"
 LABEL summary="RHTPA Operator"
-LABEL version="3.0.0"
-LABEL release=3.0.0
+LABEL version="3.1.0"
+LABEL release=3.1.0
 LABEL maintainer="Red Hat"
 LABEL operators.operatorframework.io.index.configs.v1=/config
 

--- a/Dockerfile.rhtpa-operator.rh
+++ b/Dockerfile.rhtpa-operator.rh
@@ -42,7 +42,7 @@ LABEL summary="RHTPA Operator"
 LABEL version="3.1.0"
 LABEL release=3.1.0
 LABEL maintainer="Red Hat"
-LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:3.0::el10"
+LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:3.1::el10"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -14,7 +14,7 @@ LABEL distribution-scope="public"
 LABEL url="https://www.redhat.com"
 LABEL version="3.1.0"
 LABEL release=3.1.0
-LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:3.0::el10"
+LABEL cpe="cpe:/a:redhat:trusted_profile_analyzer:3.1::el10"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"

--- a/devel/README.md
+++ b/devel/README.md
@@ -36,12 +36,12 @@ spec:
   imageDigestMirrors:
     - mirrorSourcePolicy: AllowContactingSource
       mirrors:
-        - quay.io/<your_username>/rhtpa-trustification-service-rhel10
-      source: registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel10
+        - quay.io/<your_username>/rhtpa-rhel10
+      source: registry.redhat.io/rhtpa/rhtpa-rhel10
  ```
   
 
-- Replace IF NEEDED the image ```registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel10``` in the makefile 
+- Replace IF NEEDED the image ```registry.redhat.io/rhtpa/rhtpa-rhel10``` in the makefile 
 
 # Builds the operator
 ```console

--- a/helm-charts/redhat-trusted-profile-analyzer/values.yaml
+++ b/helm-charts/redhat-trusted-profile-analyzer/values.yaml
@@ -3,7 +3,7 @@ partOf: trustify
 replicas: 1
 
 image:
-  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:49452c81d0c1e6f067fac2b7abcda38bf09273f101ffc4bd6cb62411814426f1
+  fullName: registry.redhat.io/rhtpa/rhtpa-rhel10@sha256:8ee8dcf46d807ea6881cae78dc2c8ae1bf7dc1088ade73a5940e3b88be637482
   pullPolicy: IfNotPresent
 
 rust: {}


### PR DESCRIPTION
Prepare 3.1.0

## Summary by Sourcery

Prepare the operator and bundle metadata for the 3.1.0 release and align image naming with the rhel10 image.

Enhancements:
- Update operator Dockerfile labels to use the rhel10 image name and bump version/release metadata to 3.1.0.
- Adjust bundle Dockerfile CPE label to reflect the 3.1.0 release for el10.

Documentation:
- Update development README to reference the new rhtpa-rhel10 image name instead of the previous trustification-service image.