### PR TITLE
fix for operator rbac permissions violation

### DIFF
--- a/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtpa-operator.clusterserviceversion.yaml
@@ -237,6 +237,14 @@ spec:
                 - subjectaccessreviews
               verbs:
                 - create
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
           serviceAccountName: rhtpa-operator-controller-manager
       deployments:
         - label:
@@ -345,6 +353,14 @@ spec:
               verbs:
                 - create
                 - patch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
           serviceAccountName: rhtpa-operator-controller-manager
     strategy: deployment
   installModes:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add missing RBAC rules allowing the operator to create, update, and delete networking.k8s.io NetworkPolicy resources in both referenced roles.